### PR TITLE
PodiumD 2.0.2

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 1.1.19
-appVersion: "2.0.1"
+version: 1.1.20
+appVersion: "2.0.2"
 dependencies:
   - name: keycloak
     version: 21.4.4
@@ -27,28 +27,28 @@ dependencies:
       - contact
       - zaak
   - name: openzaak
-    version: 1.3.3
+    version: 1.5.2
     repository: "@maykinmedia"
     condition: openzaak.enabled
   - name: opennotificaties
-    version: 1.3.6
+    version: 1.5.1
     repository: "@maykinmedia"
     condition: opennotificaties.enabled
   - name: objecten
-    version: 2.4.3
+    version: 2.4.4
     repository: "@maykinmedia"
     condition: objecten.enabled
   - name: objecttypen
-    version: 1.1.2
+    version: 1.1.3
     repository: "@maykinmedia"
     condition: objecttypen.enabled
   - name: openklant
-    version: 1.3.3
+    version: 1.3.5
     repository: "@maykinmedia"
     condition: openklant.enabled
   - name: openforms
     alias: openformulieren
-    version: 1.3.0
+    version: 1.4.4
     repository: "@maykinmedia"
     condition: openformulieren.enabled
   - name: openinwoner

--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -80,6 +80,22 @@
 | Open Notificaties | 1.7.1   |
 | Open Zaak         | 1.15.0  |
 
+### 2.0.2 (candidate)
+
+**PodiumD Helm chart version: 1.1.20**
+
+| Component         | Version |
+|-------------------|---------|
+| ClamAV            | 1.4.1   |
+| Keycloak          | 24.0.5  |
+| Objecten          | 2.4.4   |
+| Objecttypen       | 2.2.2   |
+| Open Formulieren  | 2.7.9   |
+| Open Inwoner      | 1.21.3  |
+| Open Klant        | 2.3.0   |
+| Open Notificaties | 1.7.1   |
+| Open Zaak         | 1.15.0  |
+
 ## Add Used chart repositories:
 
     helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -14,6 +14,10 @@ global:
     notificatiesOpenzaakSecret: notificaties-secret
     openzaakNotificatiesClientId: openzaak
     openzaakNotificatiesSecret: openzaak-secret
+
+  settings:
+    databaseHost: "podiumd-postgresql"
+
   imageRegistry: ""
 
 persistentVolume:
@@ -74,14 +78,7 @@ openzaak:
     email:
       port: 587
       useTLS: true
-    database:
-      host: ""
-      name: ""
-      username: ""
-      password: ""
-  extraEnvVars:
-    - name: DISABLE_2FA
-      value: "True"
+    disable2fa: true
   persistence:
     size: 10Gi
     existingClaim: openzaak
@@ -94,6 +91,7 @@ openzaak:
       cpu: 100m
       memory: 256Mi
   worker:
+    replicaCount: 1
     resources:
       requests:
         cpu: 10m
@@ -102,6 +100,11 @@ openzaak:
   fullnameOverride: openzaak
   flower:
     enabled: false
+  beat:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 160Mi    
   nginx:
     resources:
       requests:
@@ -110,6 +113,15 @@ openzaak:
   redis:
     nameOverride: openzaak-redis
     fullnameOverride: openzaak-redis
+    master:
+      persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: ""
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi        
 
 opennotificaties:
   configuration:
@@ -125,12 +137,6 @@ opennotificaties:
     email:
       port: 587
       useTLS: true
-    cleanOldNotifications:
-      enabled: true
-      daysRetained: 30
-      cronjob:
-        schedule: "0 0 * * *"
-        historyLimit: 1
     disable2fa: true
   persistence:
     size: 10Gi
@@ -144,6 +150,7 @@ opennotificaties:
       cpu: 100m
       memory: 256Mi
   worker:
+    replicaCount: 1
     resources:
       requests:
         cpu: 50m
@@ -166,6 +173,15 @@ opennotificaties:
   redis:
     nameOverride: opennotificaties-redis
     fullnameOverride: opennotificaties-redis
+    master:
+      persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: ""
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi        
 
 objecten:
   configuration:
@@ -189,6 +205,7 @@ objecten:
       cpu: 100m
       memory: 256Mi
   worker:
+    replicaCount: 1
     resources:
       requests:
         cpu: 50m
@@ -200,6 +217,15 @@ objecten:
   redis:
     nameOverride: objecten-redis
     fullnameOverride: objecten-redis
+    master:
+      persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: ""
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi        
 
 objecttypen:
   configuration:
@@ -222,6 +248,15 @@ objecttypen:
   redis:
     nameOverride: objecttypen-redis
     fullnameOverride: objecttypen-redis
+    master:
+      persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: ""    
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
 
 openklant:
   configuration:
@@ -232,12 +267,7 @@ openklant:
     email:
       port: 587
       useTLS: true
-    twoFactorAuthentication:
-      forceOtpAdmin: false
-      patchAdmin: false
-  extraEnvVars:
-    - name: DISABLE_2FA
-      value: "True"
+    disable2fa: true
   image:
     tag: "2.3.0"
   resources:
@@ -245,6 +275,7 @@ openklant:
       cpu: 100m
       memory: 300Mi
   worker:
+    replicaCount: 1
     resources:
       requests:
         cpu: 50m
@@ -255,11 +286,15 @@ openklant:
     nameOverride: openklant-redis
     fullnameOverride: openklant-redis
     master:
+      persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: ""
       resources:
         requests:
-          cpu: 20m
-          memory: 24Mi
-
+          cpu: 10m
+          memory: 64Mi        
+        
 openformulieren:
   configuration:
     oidcUrl: https://openformulieren.example.nl
@@ -269,9 +304,6 @@ openformulieren:
     email:
       port: 587
       useTLS: true
-    twoFactorAuthentication:
-      forceOtpAdmin: false
-      patchAdmin: false
   persistence:
     size: 10Gi
     existingClaim: openformulieren
@@ -280,14 +312,13 @@ openformulieren:
   persistentVolume:
     volumeAttributeShareName: openformulieren
   image:
-    tag: "2.7.8"
+    tag: "2.7.9"
   resources:
     requests:
       cpu: 100m
       memory: 650Mi
   worker:
-    livenessProbe:
-      initialDelaySeconds: 120
+    replicaCount: 1
     resources:
       requests:
         cpu: 50m
@@ -342,6 +373,7 @@ openinwoner:
       cpu: 200m
       memory: 1Gi
   worker:
+    replicaCount: 1
     resources:
       requests:
         cpu: 200m
@@ -359,6 +391,10 @@ openinwoner:
     nameOverride: openinwoner-redis
     fullnameOverride: openinwoner-redis
     master:
+      persistence:
+        enabled: true
+        size: 8Gi
+        storageClass: ""    
       resources:
         requests:
           cpu: 20m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -16,7 +16,7 @@ global:
     openzaakNotificatiesSecret: openzaak-secret
 
   settings:
-    databaseHost: "podiumd-postgresql"
+    databaseHost: ""
 
   imageRegistry: ""
 
@@ -312,7 +312,7 @@ openformulieren:
   persistentVolume:
     volumeAttributeShareName: openformulieren
   image:
-    tag: "2.7.9"
+    tag: "2.7.8"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
:tada: Podium 2.0.2 release:
- Update all maykin chart versions to latest versions
- Openforms patch 2.7.9 - [changelog](https://open-forms.readthedocs.io/en/latest/changelog.html#id3)

values:
- Use new `disable2fa` for all - 2fa by default uitschakelen is niet de beste default. Openforms heeft geen optie meer op 2fa uit te schakelen;
- global var voor databasehost   `globals.settings.databaseHost` kan nu gebruikt worden om database host te definiëren als deze hetzelfde is voor alle podiumd componenten;
- Redis persistence by default aan, dit ook default van de maykin charts, expliciet opgenomen om het zichtbaar te maken. 8Gi might be overkill;
- Override `worker.replicacount: 1`. Leverancier chart is default 2 (omdat dit beter is);
- Redis resources opgenomen in alle compontenten, bij sommige stond deze niet;
- Opennotificaties `cleanOldNotifications`, taak wordt nu uitgevoerd door celery beat;
- Openzaak beat resources toegevoegd, laatste chart / versie openzaak gebruikt celery beat.