### PR TITLE
Feature/podiumd 2.0.3

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 1.1.20
-appVersion: "2.0.2"
+version: 1.1.21
+appVersion: "2.0.3"
 dependencies:
   - name: keycloak
     version: 21.4.4
@@ -52,7 +52,7 @@ dependencies:
     repository: "@maykinmedia"
     condition: openformulieren.enabled
   - name: openinwoner
-    version: 1.5.2
+    version: 1.5.3
     repository: "@maykinmedia"
     condition: openinwoner.enabled
     tags:

--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -47,7 +47,7 @@
 | Open Notificaties | 1.5.2   |
 | Open Zaak         | 1.12.1  |
 
-### 2.0.0 (candidate)
+### 2.0.0
 
 **PodiumD Helm chart version: 1.1.18**
 
@@ -64,7 +64,7 @@
 | Open Zaak         | 1.15.0  |
 
 
-### 2.0.1 (candidate)
+### 2.0.1
 
 **PodiumD Helm chart version: 1.1.19**
 
@@ -80,9 +80,25 @@
 | Open Notificaties | 1.7.1   |
 | Open Zaak         | 1.15.0  |
 
-### 2.0.2 (candidate)
+### 2.0.2
 
 **PodiumD Helm chart version: 1.1.20**
+
+| Component         | Version |
+|-------------------|---------|
+| ClamAV            | 1.4.1   |
+| Keycloak          | 24.0.5  |
+| Objecten          | 2.4.4   |
+| Objecttypen       | 2.2.2   |
+| Open Formulieren  | 2.7.9   |
+| Open Inwoner      | 1.21.3  |
+| Open Klant        | 2.3.0   |
+| Open Notificaties | 1.7.1   |
+| Open Zaak         | 1.15.0  |
+
+### 2.0.3
+
+**PodiumD Helm chart version: 1.1.21**
 
 | Component         | Version |
 |-------------------|---------|

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -358,6 +358,9 @@ openinwoner:
     oidcSecret: "<openinwoner>"
   settings:
     allowedHosts: openinwoner-nginx.podiumd.svc.cluster.local
+    brpVersion: ""
+    digidMock: ""
+    eherkenningMock: ""    
     email:
       port: 587
       useTLS: true
@@ -382,6 +385,13 @@ openinwoner:
   fullnameOverride: openinwoner
   nginx:
     config:
+      basicAuth:
+        # Enable this when digid mock is set to digidMock: "true"
+        enabled: false
+        # You need to generate the encrypted basic auth password yourself with htpasswd or openssl.
+        # This is an example user
+        users: |-
+          dimpact:$apr1$E03dZmYK$npjTaXfI05tMJ63gB8dxm. 
       clientMaxBodySize: 100M
     resources:
       requests:


### PR DESCRIPTION
- :sparkles: Support Nginx Basic Authentication :lock: voor Portaal (openinwoner).

- Verzoek afscherming zie: https://dimpact.atlassian.net/browse/DS-1215

- Chart changes openinwoner: https://github.com/maykinmedia/charts/pull/139 -> :bookmark: chart version 1.5.2 -> 1.5.3

- :memo: Update README.MD (remove candidates)

- Aan values.yaml toegevoegd als voorbeeld / documtatie

- :rocket: op maykin ont omgeving, zie resultaat: https://ontw-mijn.dimpact.opengem.nl/

Disclaimer:
Bij voorkeur wordt dit gezet aan de infra kant (ingress / loadbalancer). Feature does NOT support `existing secrets`.

@sandervdbenschede Volgens mij kunnen jullie hier wel mee werken?





