### PR TITLE
fix: use correct repo for kiss chart

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -64,7 +64,7 @@ dependencies:
       - contact
   - name: kiss
     version: 1.0.6
-    repository: "@kiss"
+    repository: "@kiss-frontend"
     condition: kiss.enabled
     tags:
       - contact

--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -133,7 +133,6 @@
 
     helm repo add bitnami https://charts.bitnami.com/bitnami
     helm repo add dimpact https://Dimpact-Samenwerking.github.io/helm-charts/
-    helm repo add kiss https://Dimpact-Samenwerking.github.io/helm-charts/
     helm repo add kiss-frontend https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/KISS-frontend/main/helm
     helm repo add kiss-adapter https://raw.githubusercontent.com/ICATT-Menselijk-Digitaal/podiumd-adapter/main/helm
     helm repo add kiss-elastic https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/.github/main/docs/scripts/elastic

--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -114,7 +114,7 @@
 
 ### 3.0.0
 
-**PodiumD Helm chart version: 1.1.22**
+**PodiumD Helm chart version: 3.0.0**
 
 | Component         | Version |
 |-------------------|---------|
@@ -133,6 +133,7 @@
 
     helm repo add bitnami https://charts.bitnami.com/bitnami
     helm repo add dimpact https://Dimpact-Samenwerking.github.io/helm-charts/
+    helm repo add kiss https://Dimpact-Samenwerking.github.io/helm-charts/
     helm repo add kiss-frontend https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/KISS-frontend/main/helm
     helm repo add kiss-adapter https://raw.githubusercontent.com/ICATT-Menselijk-Digitaal/podiumd-adapter/main/helm
     helm repo add kiss-elastic https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/.github/main/docs/scripts/elastic

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -434,6 +434,7 @@ kisselastic:
       - podiumd
 
 kiss:
+  enabled: true
   configuration:
     oidcUrl: https://kiss.example.nl
     oidcSecret: "<kiss>"


### PR DESCRIPTION
Use kiss-frontend repository for the kiss chart.
Also set Helm Chart versie to 3.0.0