### PR TITLE
Merge podiumd 2.0.4 changes into the main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,27 @@
 name: Release Charts 
 
 on:
-  workflow_dispatch:
-     inputs:
-      release_version:
-        description: 'Specify the release version number'
-        required: true
-      
+  push:
+    branches:
+      - main
+      - release/*
+
 jobs:
   release:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '#release')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Set Chart and App Versions
-        run: |
-          sed -i "s/^version: .*/version: ${{ github.event.inputs.release_version }}/" charts/podiumd/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: ${{ github.event.inputs.release_version }}/" charts/podiumd/Chart.yaml
 
       - name: Add dependency chart repos
         run: |
@@ -38,7 +34,7 @@ jobs:
           helm repo add kiss-frontend https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/KISS-frontend/main/helm
           helm repo add kiss-adapter https://raw.githubusercontent.com/ICATT-Menselijk-Digitaal/podiumd-adapter/main/helm
           helm repo add kiss-elastic https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/.github/main/docs/scripts/elastic
-          
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:

--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -47,7 +47,7 @@
 | Open Notificaties | 1.5.2   |
 | Open Zaak         | 1.12.1  |
 
-### 2.0.0
+### [2.0.0](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-2.0.0)
 
 **PodiumD Helm chart version: 1.1.18**
 
@@ -64,7 +64,7 @@
 | Open Zaak         | 1.15.0  |
 
 
-### 2.0.1
+### [2.0.1](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-2.0.1)
 
 **PodiumD Helm chart version: 1.1.19**
 
@@ -80,7 +80,7 @@
 | Open Notificaties | 1.7.1   |
 | Open Zaak         | 1.15.0  |
 
-### 2.0.2
+### [2.0.2](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-2.0.2)
 
 **PodiumD Helm chart version: 1.1.20**
 
@@ -96,7 +96,7 @@
 | Open Notificaties | 1.7.1   |
 | Open Zaak         | 1.15.0  |
 
-### 2.0.3
+### [2.0.3](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-2.0.3)
 
 **PodiumD Helm chart version: 1.1.21**
 
@@ -112,7 +112,25 @@
 | Open Notificaties | 1.7.1   |
 | Open Zaak         | 1.15.0  |
 
-### 3.0.0
+### [2.0.4](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-2.0.4)
+
+**PodiumD Helm chart version: 1.1.21**
+
+Patch release for Open Inwoner bug fix.
+
+| Component         | Version | Change  |
+|-------------------|---------|---------|
+| ClamAV            | 1.4.1   |         |
+| Keycloak          | 24.0.5  |         |
+| Objecten          | 2.4.4   |         |
+| Objecttypen       | 2.2.2   |         |
+| Open Formulieren  | 2.7.9   |         |
+| Open Inwoner      | 1.21.4  | Bug fix |
+| Open Klant        | 2.3.0   |         |
+| Open Notificaties | 1.7.1   |         |
+| Open Zaak         | 1.15.0  |         |
+
+### [3.0.0](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-3.0.0)
 
 **PodiumD Helm chart version: 3.0.0**
 
@@ -128,6 +146,26 @@
 | Open Notificaties | 1.7.1   |
 | Open Zaak         | 1.15.0  |
 | KISS              | 0.5.0   |
+
+### [3.0.1](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-3.0.1)
+
+**PodiumD Helm chart version: 3.0.1**
+
+Patch release for Open Inwoner bug fix.
+
+| Component         | Version | Change  |
+|-------------------|---------|---------|
+| ClamAV            | 1.4.1   |         |
+| Keycloak          | 24.0.5  |         |
+| Objecten          | 2.4.4   |         |
+| Objecttypen       | 2.2.2   |         |
+| Open Formulieren  | 2.7.9   |         |
+| Open Inwoner      | 1.21.4  | Bug fix |
+| Open Klant        | 2.3.0   |         |
+| Open Notificaties | 1.7.1   |         |
+| Open Zaak         | 1.15.0  |         |
+| KISS              | 0.5.0   |         |
+
 
 ## Add Used chart repositories:
 

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -370,7 +370,7 @@ openinwoner:
   persistentVolume:
     volumeAttributeShareName: openinwoner
   image:
-    tag: "1.21.3"
+    tag: "1.21.4"
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
Merge changes to PodiumD 2.0.4 into main.

Mostly to allow automatic building of releases from the main branch and from release branches, but only with a #release comment in the commit.

