### PR TITLE
chore: merge podiumd 2.1.0

### DIFF
--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -69,6 +69,54 @@ Patch release for Open Inwoner bug fix.
 | Open Zaak         | 1.15.0  |         |
 | KISS              | 0.5.0   |         |
 
+### 2.0.4
+
+**PodiumD Helm chart version: 2.0.4**
+
+| Component         | Version |
+|-------------------|---------|
+| ClamAV            | 1.4.1   |
+| Keycloak          | 24.0.5  |
+| Objecten          | 2.4.4   |
+| Objecttypen       | 2.2.2   |
+| Open Formulieren  | 2.7.9   |
+| Open Inwoner      | 1.21.4  |
+| Open Klant        | 2.3.0   |
+| Open Notificaties | 1.7.1   |
+| Open Zaak         | 1.15.0  |
+
+### 2.0.5
+
+**PodiumD Helm chart version: 2.0.5**
+
+| Component         | Version |
+|-------------------|---------|
+| ClamAV            | 1.4.1   |
+| Keycloak          | 24.0.5  |
+| Objecten          | 2.4.4   |
+| Objecttypen       | 2.2.2   |
+| Open Formulieren  | 2.7.9   |
+| Open Inwoner      | 1.21.5  |
+| Open Klant        | 2.3.0   |
+| Open Notificaties | 1.7.1   |
+| Open Zaak         | 1.15.0  |
+
+### 2.1.0
+
+**PodiumD Helm chart version: 2.1.0**
+
+| Component         | Version |
+|-------------------|---------|
+| ClamAV            | 1.4.1   |
+| Keycloak          | 24.0.5  |
+| Objecten          | 2.4.4   |
+| Objecttypen       | 2.2.2   |
+| Open Formulieren  | 2.7.9   |
+| Open Inwoner      | 1.24.0  |
+| Open Klant        | 2.3.0   |
+| Open Notificaties | 1.7.1   |
+| Open Zaak         | 1.15.0  |
+
 ## Add Used chart repositories:
 
     helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -370,7 +370,7 @@ openinwoner:
   persistentVolume:
     volumeAttributeShareName: openinwoner
   image:
-    tag: "1.21.5"
+    tag: "1.24.0"
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
Changes from PodiumD 2.1.0 branch to be merged into the Main branch.

Open Inwoner version 1.21.4 was updated for PodiumD 2.1, but the main branch is ahead with version 1.24.0. And futher patches on Open Inwoner will be included in a next PodiumD patch version.