### PR TITLE
feat: kiss 1.0.1 configuratie aanpassingen

### DIFF
--- a/charts/kiss/Chart.yaml
+++ b/charts/kiss/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kiss
 description: KISS Helm chart
-version: 1.0.6
+version: 1.1.0
 appVersion: "latest"

--- a/charts/kiss/templates/frontend-config.yaml
+++ b/charts/kiss/templates/frontend-config.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   AFDELINGEN_BASE_URL: {{ default (printf "http://objecten.%s.svc.cluster.local" .Release.Namespace) .Values.objecten.baseUrl | quote }}
   AFDELINGEN_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" .Values.objecttypen.baseUrlExtern .Values.objecttypen.afdelingUUID | quote }}
-  CONTACTMOMENTEN_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
+  REGISTERS__0__CONTACTMOMENTEN_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
   ELASTIC_BASE_URL: {{ default (printf "https://kiss-es-http.%s.svc.cluster.local:9200" .Release.Namespace) .Values.elastic.baseUrl | quote }}
   {{- if .Values.email.host }}
   EMAIL_HOST: {{ .Values.email.host | quote }}
@@ -29,9 +29,9 @@ data:
   GROEPEN_BASE_URL: {{ default (printf "http://objecten.%s.svc.cluster.local" .Release.Namespace) .Values.objecten.baseUrl | quote }}
   GROEPEN_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" .Values.objecttypen.baseUrlExtern .Values.objecttypen.groepUUID | quote }}
   HAAL_CENTRAAL_BASE_URL: {{ .Values.brp.baseUrl | quote }}
-  INTERNE_TAAK_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
-  INTERNE_TAAK_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" (default (printf "http://objecttypen.%s.svc.cluster.local" .Release.Namespace) .Values.objecttypen.baseUrlIntern) .Values.objecttypen.interneTaakUUID | quote }}
-  KLANTEN_BASE_URL: {{ printf "%s/klanten" (default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl) | quote }}
+  REGISTERS__0__INTERNE_TAAK_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
+  REGISTERS__0__INTERNE_TAAK_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" (default (printf "http://objecttypen.%s.svc.cluster.local" .Release.Namespace) .Values.objecttypen.baseUrlIntern) .Values.objecttypen.interneTaakUUID | quote }}
+  REGISTERS__0__KLANTEN_BASE_URL: {{ printf "%s/klanten" (default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl) | quote }}
   KVK_BASE_URL: {{ .Values.kvk.baseUrl | quote }}
   MEDEWERKER_OBJECTEN_BASE_URL:  {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
   MEDEWERKER_OBJECTTYPES_BASE_URL: {{ .Values.objecttypen.baseUrlExtern | quote }}
@@ -45,6 +45,8 @@ data:
   POSTGRES_HOST: {{ .Values.database.host | quote }}
   SDG_OBJECT_BASE_URL: {{ default (printf "http://objecten.%s.svc.cluster.local" .Release.Namespace) .Values.objecten.baseUrl | quote }}
   SDG_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" (default (printf "http://objecttypen.%s.svc.cluster.local" .Release.Namespace) .Values.objecttypen.baseUrlIntern) .Values.objecttypen.kennisartikelUUID | quote }}
-  ZAAKSYSTEEM_DEEPLINK_PROPERTY: "identificatie"
-  ZAAKSYSTEEM_DEEPLINK_URL: {{ printf "%s/mp/zaak/" .Values.esuite.baseUrl | quote }}
-  ZAKEN_BASE_URL:  {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_DEEPLINK_PROPERTY: "identificatie"
+  REGISTERS__0__ZAAKSYSTEEM_DEEPLINK_URL: {{ printf "%s/mp/zaak/" .Values.esuite.baseUrl | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_BASE_URL:  {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.adapter.baseUrl | quote }}
+  REGISTERS__0__IS_DEFAULT: {{ .Values.esuite.isDefault | quote }}
+  REGISTERS__0__REGISTRY_VERSION: "OpenKlant1"

--- a/charts/kiss/templates/frontend-secret.yaml
+++ b/charts/kiss/templates/frontend-secret.yaml
@@ -8,8 +8,8 @@ metadata:
 stringData:
   GROEPEN_TOKEN: {{ .Values.objecten.token | quote }}
   AFDELINGEN_TOKEN: {{ .Values.objecten.token | quote }}
-  CONTACTMOMENTEN_API_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
-  CONTACTMOMENTEN_API_KEY: {{ .Values.adapter.secret | quote }}
+  REGISTERS__0__CONTACTMOMENTEN_API_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
+  REGISTERS__0__CONTACTMOMENTEN_API_KEY: {{ .Values.adapter.secret | quote }}
   ELASTIC_PASSWORD: {{ .Values.elastic.password | quote }}
   ELASTIC_USERNAME: {{ .Values.elastic.username | quote }}
   {{- if .Values.email.username }}
@@ -21,10 +21,10 @@ stringData:
   ENTERPRISE_SEARCH_PRIVATE_API_KEY: {{ .Values.enterpriseSearch.privateApikey | quote }}
   ENTERPRISE_SEARCH_PUBLIC_API_KEY: {{ .Values.enterpriseSearch.publicApikey | quote }}
   HAAL_CENTRAAL_API_KEY: {{ .Values.brp.apiKey | quote }}
-  INTERNE_TAAK_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
-  INTERNE_TAAK_CLIENT_SECRET: {{ .Values.adapter.secret | quote }}
-  KLANTEN_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
-  KLANTEN_CLIENT_SECRET: {{ .Values.adapter.secret | quote }}
+  REGISTERS__0__INTERNE_TAAK_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
+  REGISTERS__0__INTERNE_TAAK_CLIENT_SECRET: {{ .Values.adapter.secret | quote }}
+  REGISTERS__0__KLANTEN_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
+  REGISTERS__0__KLANTEN_CLIENT_SECRET: {{ .Values.adapter.secret | quote }}
   KVK_API_KEY: {{ .Values.kvk.apikey | quote }}
   MEDEWERKER_OBJECTEN_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
   MEDEWERKER_OBJECTEN_CLIENT_SECRET: {{ .Values.adapter.secret | quote }}
@@ -34,5 +34,5 @@ stringData:
   POSTGRES_PASSWORD: {{ .Values.database.password | quote }}
   POSTGRES_USER: {{ .Values.database.user | quote }}
   SDG_API_KEY: {{ .Values.objecten.token | quote }}
-  ZAKEN_API_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
-  ZAKEN_API_KEY: {{ .Values.adapter.secret | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_API_CLIENT_ID: {{ .Values.adapter.clientId | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_API_KEY: {{ .Values.adapter.secret | quote }}

--- a/charts/kiss/values.yaml
+++ b/charts/kiss/values.yaml
@@ -81,7 +81,7 @@ frontend:
     name: ""
   image:
     repository: ghcr.io/klantinteractie-servicesysteem/kiss-frontend
-    tag: "release-1.0.x-20250418091744-8936963"
+    tag: "v1.0.1"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/charts/kiss/values.yaml
+++ b/charts/kiss/values.yaml
@@ -18,6 +18,7 @@ esuite:
   clientId: kiss
   secret: ""
   contactverzoektypen: []
+  isDefault: true
 
 database:
   host: ""
@@ -80,7 +81,7 @@ frontend:
     name: ""
   image:
     repository: ghcr.io/klantinteractie-servicesysteem/kiss-frontend
-    tag: "deventer"
+    tag: "release-1.0.x-20250418091744-8936963"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/charts/podiumd/templates/frontend-config.yaml
+++ b/charts/podiumd/templates/frontend-config.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   AFDELINGEN_BASE_URL: {{ default (printf "http://objecten.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.objecten.baseUrl | quote }}
   AFDELINGEN_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" .Values.kiss.objecttypen.baseUrlExtern .Values.kiss.objecttypen.afdelingUUID | quote }}
-  CONTACTMOMENTEN_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
+  REGISTERS__0__CONTACTMOMENTEN_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
   ELASTIC_BASE_URL: {{ default (printf "https://kiss-es-http.%s.svc.cluster.local:9200" .Release.Namespace) .Values.kiss.elastic.baseUrl | quote }}
   {{- if .Values.kiss.email.host }}
   EMAIL_HOST: {{ .Values.kiss.email.host | quote }}
@@ -30,9 +30,9 @@ data:
   GROEPEN_BASE_URL: {{ default (printf "http://objecten.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.objecten.baseUrl | quote }}
   GROEPEN_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" .Values.kiss.objecttypen.baseUrlExtern .Values.kiss.objecttypen.groepUUID | quote }}
   HAAL_CENTRAAL_BASE_URL: {{ .Values.kiss.brp.baseUrl | quote }}
-  INTERNE_TAAK_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
-  INTERNE_TAAK_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" (default (printf "http://objecttypen.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.objecttypen.baseUrlIntern) .Values.kiss.objecttypen.interneTaakUUID | quote }}
-  KLANTEN_BASE_URL: {{ printf "%s/klanten" (default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl) | quote }}
+  REGISTERS__0__INTERNE_TAAK_BASE_URL: {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
+  REGISTERS__0__INTERNE_TAAK_OBJECT_TYPE_URL: {{ printf "%s/api/v2/objecttypes/%s" (default (printf "http://objecttypen.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.objecttypen.baseUrlIntern) .Values.kiss.objecttypen.interneTaakUUID | quote }}
+  REGISTERS__0__KLANTEN_BASE_URL: {{ printf "%s/klanten" (default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl) | quote }}
   KVK_BASE_URL: {{ .Values.kiss.kvk.baseUrl | quote }}
   MEDEWERKER_OBJECTEN_BASE_URL:  {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
   MEDEWERKER_OBJECTTYPES_BASE_URL: {{ .Values.kiss.objecttypen.baseUrlExtern | quote }}
@@ -50,7 +50,9 @@ data:
   VAC_OBJECTEN_BASE_URL: {{ default (printf "http://objecten.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.vac.objectenBaseUrl | quote }}
   VAC_OBJECT_TYPE_URL: {{ .Values.kiss.vac.objectTypeUrl | quote }}
   VAC_OBJECT_TYPE_VERSION: {{ .Values.kiss.vac.objectTypeVersion | quote }}
-  ZAAKSYSTEEM_DEEPLINK_PROPERTY: "identificatie"
-  ZAAKSYSTEEM_DEEPLINK_URL: {{ printf "%s/mp/zaak/" .Values.kiss.esuite.baseUrl | quote }}
-  ZAKEN_BASE_URL:  {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_DEEPLINK_PROPERTY: "identificatie"
+  REGISTERS__0__ZAAKSYSTEEM_DEEPLINK_URL: {{ printf "%s/mp/zaak/" .Values.kiss.esuite.baseUrl | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_BASE_URL:  {{ default (printf "http://kiss-adapter.%s.svc.cluster.local" .Release.Namespace) .Values.kiss.adapter.baseUrl | quote }}
+  REGISTERS__0__IS_DEFAULT: {{ .Values.kiss.esuite.isDefault | quote }}
+  REGISTERS__0__REGISTRY_VERSION: "OpenKlant1"
 {{- end }}

--- a/charts/podiumd/templates/frontend-secret.yaml
+++ b/charts/podiumd/templates/frontend-secret.yaml
@@ -9,8 +9,8 @@ metadata:
 stringData:
   GROEPEN_TOKEN: {{ .Values.kiss.objecten.token | quote }}
   AFDELINGEN_TOKEN: {{ .Values.kiss.objecten.token | quote }}
-  CONTACTMOMENTEN_API_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
-  CONTACTMOMENTEN_API_KEY: {{ .Values.kiss.adapter.secret | quote }}
+  REGISTERS__0__CONTACTMOMENTEN_API_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
+  REGISTERS__0__CONTACTMOMENTEN_API_KEY: {{ .Values.kiss.adapter.secret | quote }}
   ELASTIC_PASSWORD: {{ .Values.kiss.elastic.password | quote }}
   ELASTIC_USERNAME: {{ .Values.kiss.elastic.username | quote }}
   {{- if .Values.kiss.email.username }}
@@ -22,10 +22,10 @@ stringData:
   ENTERPRISE_SEARCH_PRIVATE_API_KEY: {{ .Values.kiss.enterpriseSearch.privateApikey | quote }}
   ENTERPRISE_SEARCH_PUBLIC_API_KEY: {{ .Values.kiss.enterpriseSearch.publicApikey | quote }}
   HAAL_CENTRAAL_API_KEY: {{ .Values.kiss.brp.apiKey | quote }}
-  INTERNE_TAAK_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
-  INTERNE_TAAK_CLIENT_SECRET: {{ .Values.kiss.adapter.secret | quote }}
-  KLANTEN_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
-  KLANTEN_CLIENT_SECRET: {{ .Values.kiss.adapter.secret | quote }}
+  REGISTERS__0__INTERNE_TAAK_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
+  REGISTERS__0__INTERNE_TAAK_CLIENT_SECRET: {{ .Values.kiss.adapter.secret | quote }}
+  REGISTERS__0__KLANTEN_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
+  REGISTERS__0__KLANTEN_CLIENT_SECRET: {{ .Values.kiss.adapter.secret | quote }}
   KVK_API_KEY: {{ .Values.kiss.kvk.apikey | quote }}
   MEDEWERKER_OBJECTEN_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
   MEDEWERKER_OBJECTEN_CLIENT_SECRET: {{ .Values.kiss.adapter.secret | quote }}
@@ -36,7 +36,7 @@ stringData:
   POSTGRES_USER: {{ .Values.kiss.database.user | quote }}
   SDG_API_KEY: {{ .Values.kiss.objecten.token | quote }}
   VAC_OBJECTEN_TOKEN: {{ .Values.kiss.vac.objectenToken | quote }}
-  ZAKEN_API_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
-  ZAKEN_API_KEY: {{ .Values.kiss.adapter.secret | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_API_CLIENT_ID: {{ .Values.kiss.adapter.clientId | quote }}
+  REGISTERS__0__ZAAKSYSTEEM_API_KEY: {{ .Values.kiss.adapter.secret | quote }}
 
 {{- end }}

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -745,6 +745,7 @@ kiss:
     clientId: kiss
     secret: ""
     contactverzoektypen: []
+    isDefault: true
 
   database:
     host: ""
@@ -807,7 +808,7 @@ kiss:
       name: ""
     image:
       repository: ghcr.io/klantinteractie-servicesysteem/kiss-frontend
-      tag: "release-0.7.x-20250331101502-2fe19fb"
+      tag: "release-1.0.x-20250418091744-8936963"
 
       pullPolicy: IfNotPresent
     resources:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -808,7 +808,8 @@ kiss:
       name: ""
     image:
       repository: ghcr.io/klantinteractie-servicesysteem/kiss-frontend
-      tag: "release-1.0.x-20250418091744-8936963"
+      tag: "v1.0.1"
+
 
       pullPolicy: IfNotPresent
     resources:


### PR DESCRIPTION
Met deze wijzigingen kan je KISS 1.0.1 draaien met de bestaande values. Let op: met deze wijzigingen is er nog GEEN manier om kiss naast de esuite ook met openzaak + openklant 2.7 te koppelen. Eventueel kan ik hier ook een voorzet voor doen maar daar is denk ik meer afstemming voor nodig.