### PR TITLE
updates for podiumd 4.5.15

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.5.14
-appVersion: "4.5.14"
+version: 4.5.15
+appVersion: "4.5.15"
 dependencies:
   # DEPRECATED: Will be removed in a future release. Use keycloak-operator instead.
   - name: keycloak

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1748,7 +1748,7 @@ openinwoner:
       port: 587
       useTLS: true
     searchIndexInitContainer: true
-    oidcFrontendLogoutWithHints: false
+    oidcFrontendLogoutWithHints: true
   persistence:
     size: 10Gi
     existingClaim: openinwoner


### PR DESCRIPTION
do not delete this branch before another branch is made off this change for podiumd 4.5.16, this allows us to generate a release from this 4.5 branch since main will be on 4.6 (or later)

### Changes:
[IN-1792]  -  Set `openformulieren.settings.oidcFrontendLogoutWithHints` to `true` 