### PR TITLE
Updates for podiumd 4.5.16

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.5.15
-appVersion: "4.5.15"
+version: 4.5.16
+appVersion: "4.5.16"
 dependencies:
   # DEPRECATED: Will be removed in a future release. Use keycloak-operator instead.
   - name: keycloak

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -92,5 +92,5 @@ dependencies:
   - name: pabc
     alias: pabc
     repository: "oci://ghcr.io/platform-autorisatie-beheer-component"
-    version: 1.0.0
+    version: 1.1.0
     condition: pabc.enabled

--- a/charts/podiumd/docs/images/images-4.5.16.yaml
+++ b/charts/podiumd/docs/images/images-4.5.16.yaml
@@ -17,12 +17,12 @@
   version: "1.1.0"
   digest: "sha256:66e83416f41d546eba8b6a7f2ea061da2d293fab6b9e22f129934127f4c31b3d"
 
-- name: pabc_migrations
+- name: pabc-migrations
   url: ghcr.io/platform-autorisatie-beheer-component/pabc-migrations
   version: "1.1.0"
   digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
 
-- name: k8s_wait_for
+- name: k8s-wait-for
   url: ghcr.io/groundnuty/k8s-wait-for
   version: "v2.0"
   digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/images/images-4.5.16.yaml
+++ b/charts/podiumd/docs/images/images-4.5.16.yaml
@@ -1,0 +1,28 @@
+# Images die nieuw of gewijzigd zijn in podiumd 4.5.16 t.o.v. 4.5.15.
+
+# Keycloak
+- name: keycloak
+  url: quay.io/keycloak/keycloak
+  version: "26.5.7"
+  digest: "sha256:45ae20191531eb608ddb0b775d012b40d3e4f942697f3214694887dd7c108d13"
+
+- name: keycloak-operator
+  url: quay.io/keycloak/keycloak-operator
+  version: "26.5.7"
+  digest: "sha256:4aaa52610f9427ef0eebbf120b24bb22cf99b7197f125b140887e2add407edce"
+
+# PABC
+- name: pabc
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-api
+  version: "1.1.0"
+  digest: "sha256:66e83416f41d546eba8b6a7f2ea061da2d293fab6b9e22f129934127f4c31b3d"
+
+- name: pabc_migrations
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-migrations
+  version: "1.1.0"
+  digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
+
+- name: pabc_wait_for
+  url: ghcr.io/groundnuty/k8s-wait-for
+  version: "v2.0"
+  digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/images/images-4.5.16.yaml
+++ b/charts/podiumd/docs/images/images-4.5.16.yaml
@@ -22,7 +22,7 @@
   version: "1.1.0"
   digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
 
-- name: pabc_wait_for
+- name: k8s_wait_for
   url: ghcr.io/groundnuty/k8s-wait-for
   version: "v2.0"
   digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
+++ b/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
@@ -14,7 +14,7 @@ For **ACR-based environments**, update the repository overrides:
 ```yaml
 pabc:
   image:
-    repository: <acr>/pabc-api
+    repository: <acr>/pabc
   migrations:
     image:
       repository: <acr>/pabc-migrations

--- a/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
+++ b/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
@@ -1,0 +1,66 @@
+# Upgrade guide: PodiumD 4.5.15 → 4.5.16
+
+## Changes
+
+### PABC bijgewerkt naar 1.1.0
+
+De PABC sub-chart is bijgewerkt van 1.0.0 naar 1.1.0. De applicatie- en migratie-images zijn bijgewerkt naar versie `1.1.0`.
+
+#### ACR image overrides
+
+Voor **ACR-gebaseerde omgevingen** moeten de repository-overrides worden bijgewerkt:
+
+```yaml
+pabc:
+  image:
+    repository: <acr>/pabc-api
+  migrations:
+    image:
+      repository: <acr>/pabc-migrations
+  initContainers:
+    waitFor:
+      image:
+        repository: <acr>/k8s-wait-for
+```
+
+Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`1.1.0` en `v2.0`).
+
+#### NodeSelector voor AKS-omgevingen
+
+Voor omgevingen die een node selector vereisen (bijv. AKS-blue met `kubernetes.azure.com/mode: user`),
+moet de nodeSelector worden ingesteld op zowel de deployment als de migration job:
+
+```yaml
+pabc:
+  nodeSelector:
+    kubernetes.azure.com/mode: user
+  migrations:
+    nodeSelector:
+      kubernetes.azure.com/mode: user
+```
+
+---
+
+### Keycloak bijgewerkt naar 26.5.7
+
+De Keycloak- en Keycloak Operator-images zijn bijgewerkt van `26.5.6` naar `26.5.7`.
+
+Voor **ACR-gebaseerde omgevingen** die de Keycloak-image overschrijven:
+
+```yaml
+keycloak:
+  image:
+    repository: <acr>/keycloak
+
+keycloak-operator:
+  operator:
+    image:
+      repository: <acr>/keycloak-operator
+```
+
+Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`26.5.7`).
+
+---
+
+Voor de volledige lijst van nieuwe en gewijzigde images in deze release, zie
+[docs/images/images-4.5.16.yaml](images/images-4.5.16.yaml).

--- a/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
+++ b/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
@@ -2,13 +2,14 @@
 
 ## Changes
 
-### PABC bijgewerkt naar 1.1.0
+### PABC updated to 1.1.0
 
-De PABC sub-chart is bijgewerkt van 1.0.0 naar 1.1.0. De applicatie- en migratie-images zijn bijgewerkt naar versie `1.1.0`.
+The PABC sub-chart has been updated from 1.0.0 to 1.1.0. The application and migration images
+have been updated to version `1.1.0`.
 
 #### ACR image overrides
 
-Voor **ACR-gebaseerde omgevingen** moeten de repository-overrides worden bijgewerkt:
+For **ACR-based environments**, update the repository overrides:
 
 ```yaml
 pabc:
@@ -23,12 +24,13 @@ pabc:
         repository: <acr>/k8s-wait-for
 ```
 
-Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`1.1.0` en `v2.0`).
+No tag overrides are needed — tags are set by the chart defaults (`1.1.0` and `v2.0`).
 
-#### NodeSelector voor AKS-omgevingen
+#### NodeSelector for AKS environments
 
-Voor omgevingen die een node selector vereisen (bijv. AKS-blue met `kubernetes.azure.com/mode: user`),
-moet de nodeSelector worden ingesteld op zowel de deployment als de migration job:
+For environments that require a node selector (e.g. AKS-blue with
+`kubernetes.azure.com/mode: user`), set the nodeSelector on both the deployment and the
+migration job:
 
 ```yaml
 pabc:
@@ -41,11 +43,11 @@ pabc:
 
 ---
 
-### Keycloak bijgewerkt naar 26.5.7
+### Keycloak updated to 26.5.7
 
-De Keycloak- en Keycloak Operator-images zijn bijgewerkt van `26.5.6` naar `26.5.7`.
+The Keycloak and Keycloak Operator images have been updated from `26.5.6` to `26.5.7`.
 
-Voor **ACR-gebaseerde omgevingen** die de Keycloak-image overschrijven:
+For **ACR-based environments**, update the repository overrides:
 
 ```yaml
 keycloak:
@@ -58,9 +60,9 @@ keycloak-operator:
       repository: <acr>/keycloak-operator
 ```
 
-Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`26.5.7`).
+No tag overrides are needed — tags are set by the chart defaults (`26.5.7`).
 
 ---
 
-Voor de volledige lijst van nieuwe en gewijzigde images in deze release, zie
+For the full list of new and changed images in this release, see
 [docs/images/images-4.5.16.yaml](images/images-4.5.16.yaml).

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -22,9 +22,9 @@ persistentVolume:
 keycloak-operator:
   enabled: true
   # Adfinis Helm chart wrapping the official Keycloak Operator manifests.
-  # Chart: https://charts.adfinis.com / adfinis/keycloak-operator (appVersion 26.5.6)
+  # Chart: https://charts.adfinis.com / adfinis/keycloak-operator (appVersion 26.5.7)
   # Note: it appears that the podname automatically appends -operator.
-  # Official operator image: quay.io/keycloak/keycloak-operator:26.5.6
+  # Official operator image: quay.io/keycloak/keycloak-operator:26.5.7
   fullnameOverride: keycloak
   operator:
     image:
@@ -111,7 +111,7 @@ keycloak:
   http:
     httpEnabled: true
   # image parameters for keycloak-operator
-  # Official Keycloak image: quay.io/keycloak/keycloak:26.5.6
+  # Official Keycloak image: quay.io/keycloak/keycloak:26.5.7
   image:
     repository: quay.io/keycloak/keycloak
     tag: 26.5.7
@@ -151,7 +151,7 @@ keycloak:
     metadata:
       labels:
         app: keycloak
-        version: 26.5.6
+        version: 26.5.7
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2535,6 +2535,7 @@ pabc:
     enabled: false
   image:
     tag: 1.1.0
+  nodeSelector: {}
   migrations:
     image:
       tag: 1.1.0

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -29,7 +29,7 @@ keycloak-operator:
   operator:
     image:
       repository: quay.io/keycloak/keycloak-operator
-      tag: "26.5.6"
+      tag: "26.5.7"
   serviceAccount:
     create: false
 
@@ -100,6 +100,7 @@ keycloak:
         enabled: true
         secret: "monitoring_secret"
         oidcUrl: "https://monitoring.example.nl"
+  enabled: false
   name: "keycloak"
   features:
     enabled: []
@@ -113,7 +114,7 @@ keycloak:
   # Official Keycloak image: quay.io/keycloak/keycloak:26.5.6
   image:
     repository: quay.io/keycloak/keycloak
-    tag: 26.5.6
+    tag: 26.5.7
   # -- instances is the new operator-style replica count (falls back to replicaCount)
   instances: "2"
   ingress:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2534,10 +2534,17 @@ pabc:
   postgresql:
     enabled: false
   image:
-    tag: 1.0.0
+    tag: 1.1.0
   migrations:
     image:
-      tag: 1.0.0
+      tag: 1.1.0
+    nodeSelector: {}
+  initContainers:
+    waitFor:
+      image:
+        repository: "ghcr.io/groundnuty/k8s-wait-for"
+        tag: "v2.0"
+        pullPolicy: IfNotPresent
 
   settings:
     database:


### PR DESCRIPTION
do not delete this branch before another branch is made off this change for podiumd 4.5.17, this allows us to generate a release from this 4.5 branch since main will be on 4.6 (or later)