### PR TITLE
hotfix: pabc update for podiumd 4.6.2

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -3,7 +3,7 @@ name: podiumd
 description: PodiumD Helm chart
 type: application
 version: 4.6.2
-appVersion: "4.6.1"
+appVersion: "4.6.2"
 dependencies:
   - name: keycloak-operator
     version: 1.11.2
@@ -91,7 +91,7 @@ dependencies:
   - name: pabc
     alias: pabc
     repository: "oci://ghcr.io/platform-autorisatie-beheer-component"
-    version: 1.0.0
+    version: 1.1.0
     condition: pabc.enabled
   - name: notifynl-omc-nodep
     alias: omc

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.5.15
-appVersion: "4.5.15"
+version: 4.5.16
+appVersion: "4.5.16"
 dependencies:
   # DEPRECATED: Will be removed in a future release. Use keycloak-operator instead.
   - name: keycloak

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.5.14
-appVersion: "4.5.14"
+version: 4.5.15
+appVersion: "4.5.15"
 dependencies:
   # DEPRECATED: Will be removed in a future release. Use keycloak-operator instead.
   - name: keycloak

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.6.1
+version: 4.6.2
 appVersion: "4.6.1"
 dependencies:
   - name: keycloak-operator

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -92,5 +92,5 @@ dependencies:
   - name: pabc
     alias: pabc
     repository: "oci://ghcr.io/platform-autorisatie-beheer-component"
-    version: 1.0.0
+    version: 1.1.0
     condition: pabc.enabled

--- a/charts/podiumd/README.md
+++ b/charts/podiumd/README.md
@@ -2,6 +2,50 @@
 
 ## PodiumD versions
 
+### [4.6.2](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-4.6.2)
+
+**PodiumD Helm chart version: 4.6.2**
+Componenten op alphabetische volgorde, met sub-charts er onder:
+
+| Component                 | AppVersion   | Change        | ChartVersion | Change        | **Notes**                 |
+|---------------------------|--------------|---------------|--------------|---------------|---------------------------|
+| BRP Mock                  |              |               | 1.2.8        |               | Only on Test Environments |
+| ClamAV                    | 1.4.4        |               | 3.7.1        |               |                           |
+| ITA                       | 3.0.0        |               | 3.0.0        |               |                           |
+| - Ita poller              | 3.0.0        |               |              |               |                           |
+| Keycloak                  | 26.5.7       |               | 1.11.2       | Operator      |                           |
+| Kiss                      | 2.2.2        |               | 2.2.2        |               |                           |
+| - Kiss Elastic            |              |               | 1.1.0        |               |                           |
+| - Kiss ElasticSync        | 0.3.2        |               |              |               |                           |
+| - PodiumD Adapter         | 0.6.6        |               |              |               |                           |
+| Objecten                  | 3.6.0        |               | 2.12.0       |               |                           |
+| Objecttypen               | 3.4.1        |               | 1.6.1        |               |                           |
+| OMC for NotifyNL          | 1.17.18      |               | 0.14.0       |               |                           |
+| Open Archiefbeheer        | 1.1.1        |               | 1.5.3        |               |                           |
+| Open Formulieren          | 3.4.7        |               | 1.12.0       |               |                           |
+| Open Inwoner              | 2.1.1        |               | 2.1.3        |               |                           |
+| Open Klant                | 2.15.0       |               | 1.11.0       |               |                           |
+| Open Notificaties         | 1.15.0       |               | 1.13.1       |               |                           |
+| Open Zaak                 | 1.26.0       |               | 1.13.1       |               |                           |
+| PABC                      | 1.1.0        | Patch update  | 1.1.0        | Patch update  |                           |
+| - k8s-wait-for            | v2.0         | New           |              |               |                           |
+| Redis Operator            | v0.24.0      |               | 0.24.0       |               |                           |
+| - Busybox                 | 1.37.0-glibc |               |              |               |                           |
+| - Redis                   | v8.4.2       |               |              |               |                           |
+| - Redis Exporter          | v1.44.0      |               |              |               |                           |
+| Zac                       | 4.3.61       |               | 1.0.208      |               |                           |
+| - Busybox                 | 1.37.0       |               |              |               |                           |
+| - Curl                    | 8.18.0       |               |              |               |                           |
+| - Kubectl                 | 1.25.4       |               |              |               |                           |
+| - Nginx                   | 1.29.5       |               |              |               |                           |
+| - Opa                     | 1.14.0       |               |              |               |                           |
+| - Opentelemetry Collector | 0.146.1      |               | 0.146.0      |               | Operator                  |
+| - Solr                    | 9.10.1       |               | 0.9.1        |               |                           |
+| - Office Converter        | 1.8.2        |               |              |               |                           |
+| - Zookeeper               | 0.2.15       |               | 0.2.15       |               | Operator                  |
+| ZGW Office Addin          | 0.9.133      |               | 0.0.73       |               |                           |
+
+
 ### [4.6.1](https://github.com/Dimpact-Samenwerking/helm-charts/releases/tag/podiumd-4.6.1)
 
 **PodiumD Helm chart version: 4.6.1**

--- a/charts/podiumd/docs/images/images-4.5.16.yaml
+++ b/charts/podiumd/docs/images/images-4.5.16.yaml
@@ -17,12 +17,12 @@
   version: "1.1.0"
   digest: "sha256:66e83416f41d546eba8b6a7f2ea061da2d293fab6b9e22f129934127f4c31b3d"
 
-- name: pabc_migrations
+- name: pabc-migrations
   url: ghcr.io/platform-autorisatie-beheer-component/pabc-migrations
   version: "1.1.0"
   digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
 
-- name: k8s_wait_for
+- name: k8s-wait-for
   url: ghcr.io/groundnuty/k8s-wait-for
   version: "v2.0"
   digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/images/images-4.5.16.yaml
+++ b/charts/podiumd/docs/images/images-4.5.16.yaml
@@ -1,0 +1,28 @@
+# Images die nieuw of gewijzigd zijn in podiumd 4.5.16 t.o.v. 4.5.15.
+
+# Keycloak
+- name: keycloak
+  url: quay.io/keycloak/keycloak
+  version: "26.5.7"
+  digest: "sha256:45ae20191531eb608ddb0b775d012b40d3e4f942697f3214694887dd7c108d13"
+
+- name: keycloak-operator
+  url: quay.io/keycloak/keycloak-operator
+  version: "26.5.7"
+  digest: "sha256:4aaa52610f9427ef0eebbf120b24bb22cf99b7197f125b140887e2add407edce"
+
+# PABC
+- name: pabc
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-api
+  version: "1.1.0"
+  digest: "sha256:66e83416f41d546eba8b6a7f2ea061da2d293fab6b9e22f129934127f4c31b3d"
+
+- name: pabc_migrations
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-migrations
+  version: "1.1.0"
+  digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
+
+- name: pabc_wait_for
+  url: ghcr.io/groundnuty/k8s-wait-for
+  version: "v2.0"
+  digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/images/images-4.5.16.yaml
+++ b/charts/podiumd/docs/images/images-4.5.16.yaml
@@ -22,7 +22,7 @@
   version: "1.1.0"
   digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
 
-- name: pabc_wait_for
+- name: k8s_wait_for
   url: ghcr.io/groundnuty/k8s-wait-for
   version: "v2.0"
   digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/images/images-4.6.2.yaml
+++ b/charts/podiumd/docs/images/images-4.6.2.yaml
@@ -1,0 +1,18 @@
+# Images die nieuw of gewijzigd zijn in podiumd 4.6.2 t.o.v. 4.6.1.
+# NB: deze images waren al aanwezig in de laatste 4.5 patch (podiumd 4.5.16).
+
+# PABC
+- name: pabc
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-api
+  version: "1.1.0"
+  digest: "sha256:66e83416f41d546eba8b6a7f2ea061da2d293fab6b9e22f129934127f4c31b3d"
+
+- name: pabc-migrations
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-migrations
+  version: "1.1.0"
+  digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
+
+- name: k8s-wait-for
+  url: ghcr.io/groundnuty/k8s-wait-for
+  version: "v2.0"
+  digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
+++ b/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
@@ -14,7 +14,7 @@ For **ACR-based environments**, update the repository overrides:
 ```yaml
 pabc:
   image:
-    repository: <acr>/pabc-api
+    repository: <acr>/pabc
   migrations:
     image:
       repository: <acr>/pabc-migrations

--- a/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
+++ b/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
@@ -1,0 +1,66 @@
+# Upgrade guide: PodiumD 4.5.15 → 4.5.16
+
+## Changes
+
+### PABC bijgewerkt naar 1.1.0
+
+De PABC sub-chart is bijgewerkt van 1.0.0 naar 1.1.0. De applicatie- en migratie-images zijn bijgewerkt naar versie `1.1.0`.
+
+#### ACR image overrides
+
+Voor **ACR-gebaseerde omgevingen** moeten de repository-overrides worden bijgewerkt:
+
+```yaml
+pabc:
+  image:
+    repository: <acr>/pabc-api
+  migrations:
+    image:
+      repository: <acr>/pabc-migrations
+  initContainers:
+    waitFor:
+      image:
+        repository: <acr>/k8s-wait-for
+```
+
+Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`1.1.0` en `v2.0`).
+
+#### NodeSelector voor AKS-omgevingen
+
+Voor omgevingen die een node selector vereisen (bijv. AKS-blue met `kubernetes.azure.com/mode: user`),
+moet de nodeSelector worden ingesteld op zowel de deployment als de migration job:
+
+```yaml
+pabc:
+  nodeSelector:
+    kubernetes.azure.com/mode: user
+  migrations:
+    nodeSelector:
+      kubernetes.azure.com/mode: user
+```
+
+---
+
+### Keycloak bijgewerkt naar 26.5.7
+
+De Keycloak- en Keycloak Operator-images zijn bijgewerkt van `26.5.6` naar `26.5.7`.
+
+Voor **ACR-gebaseerde omgevingen** die de Keycloak-image overschrijven:
+
+```yaml
+keycloak:
+  image:
+    repository: <acr>/keycloak
+
+keycloak-operator:
+  operator:
+    image:
+      repository: <acr>/keycloak-operator
+```
+
+Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`26.5.7`).
+
+---
+
+Voor de volledige lijst van nieuwe en gewijzigde images in deze release, zie
+[docs/images/images-4.5.16.yaml](images/images-4.5.16.yaml).

--- a/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
+++ b/charts/podiumd/docs/upgrade-from-4.5.15-to-4.5.16.md
@@ -2,13 +2,14 @@
 
 ## Changes
 
-### PABC bijgewerkt naar 1.1.0
+### PABC updated to 1.1.0
 
-De PABC sub-chart is bijgewerkt van 1.0.0 naar 1.1.0. De applicatie- en migratie-images zijn bijgewerkt naar versie `1.1.0`.
+The PABC sub-chart has been updated from 1.0.0 to 1.1.0. The application and migration images
+have been updated to version `1.1.0`.
 
 #### ACR image overrides
 
-Voor **ACR-gebaseerde omgevingen** moeten de repository-overrides worden bijgewerkt:
+For **ACR-based environments**, update the repository overrides:
 
 ```yaml
 pabc:
@@ -23,12 +24,13 @@ pabc:
         repository: <acr>/k8s-wait-for
 ```
 
-Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`1.1.0` en `v2.0`).
+No tag overrides are needed — tags are set by the chart defaults (`1.1.0` and `v2.0`).
 
-#### NodeSelector voor AKS-omgevingen
+#### NodeSelector for AKS environments
 
-Voor omgevingen die een node selector vereisen (bijv. AKS-blue met `kubernetes.azure.com/mode: user`),
-moet de nodeSelector worden ingesteld op zowel de deployment als de migration job:
+For environments that require a node selector (e.g. AKS-blue with
+`kubernetes.azure.com/mode: user`), set the nodeSelector on both the deployment and the
+migration job:
 
 ```yaml
 pabc:
@@ -41,11 +43,11 @@ pabc:
 
 ---
 
-### Keycloak bijgewerkt naar 26.5.7
+### Keycloak updated to 26.5.7
 
-De Keycloak- en Keycloak Operator-images zijn bijgewerkt van `26.5.6` naar `26.5.7`.
+The Keycloak and Keycloak Operator images have been updated from `26.5.6` to `26.5.7`.
 
-Voor **ACR-gebaseerde omgevingen** die de Keycloak-image overschrijven:
+For **ACR-based environments**, update the repository overrides:
 
 ```yaml
 keycloak:
@@ -58,9 +60,9 @@ keycloak-operator:
       repository: <acr>/keycloak-operator
 ```
 
-Er zijn geen tag-overrides nodig — de tags worden bepaald door de chart-standaarden (`26.5.7`).
+No tag overrides are needed — tags are set by the chart defaults (`26.5.7`).
 
 ---
 
-Voor de volledige lijst van nieuwe en gewijzigde images in deze release, zie
+For the full list of new and changed images in this release, see
 [docs/images/images-4.5.16.yaml](images/images-4.5.16.yaml).

--- a/charts/podiumd/docs/upgrade-from-4.6.1-to-4.6.2.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.1-to-4.6.2.md
@@ -65,7 +65,7 @@ using the Keycloak Operator (`keycloak-operator.enabled: true`). No action neede
 
 | Component | 4.6.1 | 4.6.2 |
 |---|---|---|
-| pabc | 1.0.0 | 1.1.0 |
+| pabc (chart + image/app version) | 1.0.0 | 1.1.0 |
 
 ---
 

--- a/charts/podiumd/docs/upgrade-from-4.6.1-to-4.6.2.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.1-to-4.6.2.md
@@ -1,0 +1,71 @@
+# Upgrade guide: PodiumD 4.6.1 → 4.6.2
+
+## New features / additions
+
+### PABC updated to 1.1.0
+
+The PABC application and migration images have been updated from `1.0.0` to `1.1.0`.
+
+#### ACR image overrides
+
+For **ACR-based environments**, update the repository overrides:
+
+```yaml
+pabc:
+  image:
+    repository: <acr>/pabc
+  migrations:
+    image:
+      repository: <acr>/pabc-migrations
+  initContainers:
+    waitFor:
+      image:
+        repository: <acr>/k8s-wait-for
+```
+
+No tag overrides are needed — tags are set by the chart defaults (`1.1.0` and `v2.0`).
+
+#### New initContainer: k8s-wait-for
+
+PABC 1.1.0 introduces an init container that waits for the migration job to complete before
+the main application pod starts. The image (`ghcr.io/groundnuty/k8s-wait-for:v2.0`) is a
+**new image** in this release.
+
+For **ACR-based environments** that do not yet have this image in the ACR, add the override above
+so the image is pulled from the environment-specific ACR.
+
+#### NodeSelector for AKS environments
+
+For environments that require a node selector (e.g. AKS-blue with
+`kubernetes.azure.com/mode: user`), set the nodeSelector on both the deployment and the
+migration job:
+
+```yaml
+pabc:
+  nodeSelector:
+    kubernetes.azure.com/mode: user
+  migrations:
+    nodeSelector:
+      kubernetes.azure.com/mode: user
+```
+
+---
+
+### Legacy Bitnami Keycloak explicitly disabled
+
+`keycloak.enabled` is now explicitly set to `false` in the chart defaults. This has no
+functional impact — the legacy Bitnami Keycloak chart was already inactive in environments
+using the Keycloak Operator (`keycloak-operator.enabled: true`). No action needed.
+
+---
+
+## Component version bumps (chart defaults — no action needed in env values)
+
+| Component | 4.6.1 | 4.6.2 |
+|---|---|---|
+| pabc | 1.0.0 | 1.1.0 |
+
+---
+
+For the full list of new and changed images in this release, see
+[docs/images/images-4.6.2.yaml](images/images-4.6.2.yaml).

--- a/charts/podiumd/docs/upgrade-from-4.6.1-to-4.6.2.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.1-to-4.6.2.md
@@ -4,6 +4,8 @@
 
 ### PABC updated to 1.1.0
 
+> **Note:** These PABC changes were already included in the latest 4.5 patch release (podiumd 4.5.16). Environments that have already upgraded to 4.5.16 before migrating to 4.6.x have these images in their ACR and no new ACR imports are required.
+
 The PABC application and migration images have been updated from `1.0.0` to `1.1.0`.
 
 #### ACR image overrides

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -22,9 +22,9 @@ persistentVolume:
 keycloak-operator:
   enabled: true
   # Adfinis Helm chart wrapping the official Keycloak Operator manifests.
-  # Chart: https://charts.adfinis.com / adfinis/keycloak-operator (appVersion 26.5.6)
+  # Chart: https://charts.adfinis.com / adfinis/keycloak-operator (appVersion 26.5.7)
   # Note: it appears that the podname automatically appends -operator.
-  # Official operator image: quay.io/keycloak/keycloak-operator:26.5.6
+  # Official operator image: quay.io/keycloak/keycloak-operator:26.5.7
   fullnameOverride: keycloak
   operator:
     image:
@@ -111,7 +111,7 @@ keycloak:
   http:
     httpEnabled: true
   # image parameters for keycloak-operator
-  # Official Keycloak image: quay.io/keycloak/keycloak:26.5.6
+  # Official Keycloak image: quay.io/keycloak/keycloak:26.5.7
   image:
     repository: quay.io/keycloak/keycloak
     tag: 26.5.7
@@ -151,7 +151,7 @@ keycloak:
     metadata:
       labels:
         app: keycloak
-        version: 26.5.6
+        version: 26.5.7
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2535,6 +2535,7 @@ pabc:
     enabled: false
   image:
     tag: 1.1.0
+  nodeSelector: {}
   migrations:
     image:
       tag: 1.1.0

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -29,7 +29,7 @@ keycloak-operator:
   operator:
     image:
       repository: quay.io/keycloak/keycloak-operator
-      tag: "26.5.6"
+      tag: "26.5.7"
   serviceAccount:
     create: false
 
@@ -100,6 +100,7 @@ keycloak:
         enabled: true
         secret: "monitoring_secret"
         oidcUrl: "https://monitoring.example.nl"
+  enabled: false
   name: "keycloak"
   features:
     enabled: []
@@ -113,7 +114,7 @@ keycloak:
   # Official Keycloak image: quay.io/keycloak/keycloak:26.5.6
   image:
     repository: quay.io/keycloak/keycloak
-    tag: 26.5.6
+    tag: 26.5.7
   # -- instances is the new operator-style replica count (falls back to replicaCount)
   instances: "2"
   ingress:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1748,7 +1748,7 @@ openinwoner:
       port: 587
       useTLS: true
     searchIndexInitContainer: true
-    oidcFrontendLogoutWithHints: false
+    oidcFrontendLogoutWithHints: true
   persistence:
     size: 10Gi
     existingClaim: openinwoner

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2534,10 +2534,17 @@ pabc:
   postgresql:
     enabled: false
   image:
-    tag: 1.0.0
+    tag: 1.1.0
   migrations:
     image:
-      tag: 1.0.0
+      tag: 1.1.0
+    nodeSelector: {}
+  initContainers:
+    waitFor:
+      image:
+        repository: "ghcr.io/groundnuty/k8s-wait-for"
+        tag: "v2.0"
+        pullPolicy: IfNotPresent
 
   settings:
     database:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -152,7 +152,6 @@ keycloak:
         enabled: true
         secret: "monitoring_secret"
         oidcUrl: "https://monitoring.example.nl"
-  enabled: false
   name: "keycloak"
   features:
     enabled: []


### PR DESCRIPTION
This pull request updates the PodiumD Helm chart and its documentation to support new versions of PABC, including image and configuration changes. The main focus is on upgrading PABC to 1.1.0, with associated guidance for deployments and image overrides.

**Dependency and image updates:**

* Upgraded PABC application and migration images from version 1.0.0 to 1.1.0, and added configuration for the `k8s-wait-for` init container image. (`charts/podiumd/values.yaml` [[1]](diffhunk://#diff-e047d8a8c6158fee505ea5eeb53585630c94dff2a72b30fbda483b08b29024fdL2910-R2922) `charts/podiumd/docs/images/images-4.5.16.yaml` [[2]](diffhunk://#diff-7e4827a59c405eafc5e781bc3e085d38cb4fd8c1b2246ebe3afa641b20ee95e7R1-R28)

**Documentation and configuration:**

* Updated the chart version to 4.6.2 in `Chart.yaml`. (`charts/podiumd/Chart.yaml` [charts/podiumd/Chart.yamlL5-R5](diffhunk://#diff-6d5b8277b51a753782f41b31c490e980555e4dac5f211d13fdfd4cbde2d8790eL5-R5))

**Other configuration changes:**

* Added default `nodeSelector` fields for PABC deployments and migrations, and disabled the Keycloak feature flag by default. (`charts/podiumd/values.yaml` [[1]](diffhunk://#diff-e047d8a8c6158fee505ea5eeb53585630c94dff2a72b30fbda483b08b29024fdL2910-R2922) [[2]](diffhunk://#diff-e047d8a8c6158fee505ea5eeb53585630c94dff2a72b30fbda483b08b29024fdR155)