### PR TITLE
monitoring-logging 1.0.13: scope Alloy to podiumd+monitoring, pin to userpool, fix log rotation

### DIFF
--- a/charts/monitoring-logging/Chart.yaml
+++ b/charts/monitoring-logging/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: monitoring-logging
 description: A monitoring stack using Loki, Prometheus, Grafana Alloy, OpenTelemetry Collector, and Grafana. Optionally includes Grafana Tempo for distributed tracing.
 type: application
-version: 1.0.12
-appVersion: "1.0.12"
+version: 1.0.13
+appVersion: "1.0.13"
 dependencies:
   - name: loki
     repository: "@grafana"

--- a/charts/monitoring-logging/docs/upgrade-from-1.0.12-to-1.0.13.md
+++ b/charts/monitoring-logging/docs/upgrade-from-1.0.12-to-1.0.13.md
@@ -1,0 +1,122 @@
+# Upgrade guide: monitoring-logging 1.0.12 → 1.0.13
+
+## Summary of changes
+
+This release narrows Alloy's log collection scope to the `podiumd` and `monitoring` namespaces, pins Alloy to the user pool, and fixes the log path so container restarts (0.log → 1.log → …) keep being captured.
+
+Three coupled changes in `charts/monitoring-logging/values.yaml` (Alloy config + scheduling), plus a `Chart.yaml` version bump. No env values changes are required, but operators with non-`userpool` pool naming should override `alloy.controller.nodeSelector`.
+
+### 1. Namespace-scoped log discovery
+
+The Alloy `discovery.kubernetes "pods"` block now uses a server-side namespace filter:
+
+```alloy
+discovery.kubernetes "pods" {
+  role = "pod"
+
+  namespaces {
+    names = ["podiumd", "monitoring"]
+  }
+}
+```
+
+This narrows the K8s API watch (LIST/WATCH is namespace-scoped) instead of fetching all pods cluster-wide and dropping them with a relabel rule. Lower API server load, less memory in Alloy, fewer log lines flowing to Loki.
+
+If your deployment needs different namespaces, override the entire `alloy.alloy.configMap.content` block in your env values file (the configMap content is a single string, so partial override is not supported).
+
+### 2. `nodeSelector` pinned to user pool
+
+The Alloy DaemonSet is now scheduled only on user pool nodes:
+
+```yaml
+alloy:
+  controller:
+    nodeSelector:
+      kubernetes.azure.com/agentpool: userpool
+```
+
+This **reverses the 1.0.11 → 1.0.12 guidance** to leave Alloy unconstrained. The reversal is intentional and only safe given change #1: with log capture narrowed to `podiumd` + `monitoring`, both of which run on the user pool, there is nothing to collect on system or other pools.
+
+If you change the namespace list to include workloads that run on other pools, **also remove or widen this nodeSelector** — otherwise pods on excluded pools become invisible.
+
+Operators with a different pool name override the value in their env values file:
+
+```yaml
+alloy:
+  controller:
+    nodeSelector:
+      kubernetes.azure.com/agentpool: <your-pool-name>
+```
+
+### 3. Log path glob + `local.file_match`
+
+Container log files rotate on restart (`0.log`, `1.log`, `2.log`, …). The 1.0.11 fix used a literal `/0.log` path because `loki.source.file` does `os.Stat` directly and cannot resolve globs. That meant logs were lost on every container restart.
+
+1.0.13 introduces `local.file_match` to expand the glob into real file paths:
+
+```alloy
+rule {
+  ...
+  replacement = "/var/log/pods/${1}_${2}_${3}/${4}/*.log"
+  target_label = "__path__"
+}
+
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+  sync_period  = "10s"
+}
+
+loki.source.file "pod_logs" {
+  targets    = local.file_match.pod_logs.targets
+  forward_to = [loki.process.cri.receiver]
+}
+```
+
+`sync_period = "10s"` is how often Alloy re-scans the filesystem for newly rotated files. After a container restart, the new `1.log` is picked up within 10 seconds.
+
+## Why this overrides the 1.0.11 → 1.0.12 guidance
+
+| Concern (from 1.0.11→1.0.12) | Why it doesn't apply here |
+|---|---|
+| "Alloy is a DaemonSet and must run on every node to collect logs cluster-wide." | Cluster-wide capture is no longer the goal — scope is explicitly `podiumd` + `monitoring` only. |
+| "A nodeSelector restricts it to a single pool, leaving pods on other pools without log shipping." | Workloads in scope run only on the user pool. Pods that *do* land on other pools (system add-ons, etc.) are intentionally out of scope. |
+| "Cost pool isolation: even if user workloads run only on userpool, system workloads on systempool still produce logs worth capturing." | Decision: those system-pool logs are not in scope for this deployment. |
+
+The 1.0.11 → 1.0.12 doc remains correct **for cluster-wide log capture deployments**. 1.0.13 is for the narrower podiumd-only scope.
+
+## Operator action
+
+For most deployments: nothing to do beyond `helm upgrade`. The chart defaults handle namespace scope, scheduling, and log path.
+
+If your env values file has a manually-added `alloy.nodeSelector` block (per the now-superseded 1.0.11 guidance), remove it — the chart now sets `alloy.controller.nodeSelector` correctly. Note the path difference: `alloy.nodeSelector` was silently ignored by the Grafana Alloy subchart (which expects `alloy.controller.nodeSelector`), so the previous block was likely a no-op anyway.
+
+If your user pool is not named `userpool` or uses a different label key, override:
+
+```yaml
+# values-monitoring-<env>.yaml
+alloy:
+  controller:
+    nodeSelector:
+      kubernetes.azure.com/agentpool: <your-pool-name>
+```
+
+## Verification after upgrade
+
+```bash
+# 1. Alloy pods are only on user-pool nodes
+kubectl -n <namespace> get pods -l app.kubernetes.io/name=alloy -o wide
+
+# 2. Alloy is healthy (no config validation errors)
+kubectl -n <namespace> logs -l app.kubernetes.io/name=alloy --tail=50
+
+# 3. Logs from podiumd + monitoring are flowing into Loki
+#    (query in Grafana: {namespace="podiumd"} or {namespace="monitoring"})
+
+# 4. Container restart capture works:
+#    delete a podiumd pod and confirm new 1.log entries appear in Loki
+#    within ~10s of the new container starting.
+```
+
+## No other changes
+
+This release is targeted at Alloy. No other component versions, image tags, or schema changes.

--- a/charts/monitoring-logging/values.yaml
+++ b/charts/monitoring-logging/values.yaml
@@ -393,6 +393,14 @@ prometheus-pushgateway:
 
 alloy:
   enabled: true
+  # -- DaemonSet scheduling. Pin Alloy to the user pool because the
+  # discovery.kubernetes namespaces filter below scopes log capture to
+  # podiumd + monitoring, both of which run on the user pool. See
+  # docs/upgrade-from-1.0.12-to-1.0.13.md for why this overrides the
+  # 1.0.11→1.0.12 guidance to leave Alloy without a nodeSelector.
+  controller:
+    nodeSelector:
+      kubernetes.azure.com/agentpool: userpool
   alloy:
     extraEnv:
       - name: NODE_NAME
@@ -402,13 +410,18 @@ alloy:
     # -- configMap.content is processed by Helm tpl, so {{ .Release.Name }} is valid
     configMap:
       content: |
-        // Discover all pods on the node
+        // Discover only podiumd + monitoring namespace pods.
+        // Server-side namespace filter: scopes the API watch, not just a relabel drop.
         discovery.kubernetes "pods" {
           role = "pod"
+
+          namespaces {
+            names = ["podiumd", "monitoring"]
+          }
         }
 
         // Relabel: keep only pods on this node, drop terminated pods,
-        // extract exact log path from pod UID, add k8s metadata.
+        // build the log path glob, add k8s metadata.
         discovery.relabel "pod_logs" {
           targets = discovery.kubernetes.pods.targets
 
@@ -446,21 +459,31 @@ alloy:
             target_label  = "app"
           }
 
-          // Build the exact log file path using pod UID — no wildcards, os.Stat requires a real path.
+          // Build the log path glob — *.log captures all container restarts
+          // (0.log, 1.log, …). local.file_match below expands the glob into
+          // real file paths; without it, loki.source.file would os.Stat the
+          // literal "*.log" string and skip every target.
           // Use ${n} notation: $n_ would include the underscore in the capture group reference.
           rule {
             source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name", "__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
             separator     = "/"
             regex         = "(.+)/(.+)/(.+)/(.+)"
-            replacement   = "/var/log/pods/${1}_${2}_${3}/${4}/0.log"
+            replacement   = "/var/log/pods/${1}_${2}_${3}/${4}/*.log"
             target_label  = "__path__"
           }
+        }
+
+        // Resolve __path__ globs into concrete files (0.log, 1.log, …).
+        // sync_period determines how often new rotated files are picked up.
+        local.file_match "pod_logs" {
+          path_targets = discovery.relabel.pod_logs.output
+          sync_period  = "10s"
         }
 
         // Tail log files, strip CRI prefix (containerd format: timestamp stream flags log)
         // and forward to Loki. Equivalent to Promtail's pipeline_stages: [cri: {}].
         loki.source.file "pod_logs" {
-          targets    = discovery.relabel.pod_logs.output
+          targets    = local.file_match.pod_logs.targets
           forward_to = [loki.process.cri.receiver]
         }
 


### PR DESCRIPTION
## Summary

IN-1929. Three coupled changes to Alloy in monitoring-logging 1.0.13:

- **Namespace scope** — `discovery.kubernetes "pods"` now uses a server-side namespace filter (`namespaces.names = ["podiumd", "monitoring"]`) instead of a cluster-wide watch with relabel-drop. Lower API server load and less memory in Alloy.
- **Scheduling** — Pin Alloy DaemonSet to user pool (`alloy.controller.nodeSelector = kubernetes.azure.com/agentpool: userpool`). This reverses the 1.0.11→1.0.12 guidance, which is safe given the narrower scope: both in-scope namespaces run only on the user pool. See the new upgrade doc for full reasoning.
- **Log rotation fix** — `__path__` uses `/*.log` instead of literal `/0.log` and a new `local.file_match` component resolves the glob into real file paths. Without this, logs were lost on every container restart.

## Why the nodeSelector reversal is safe here

The 1.0.11→1.0.12 doc removed the Alloy nodeSelector because pinning a DaemonSet to one pool leaves logs uncollected on other pools. That reasoning assumes cluster-wide log capture. With 1.0.13's namespace filter, `podiumd`+`monitoring` are the only scope, both run on user pool, so workloads on system/other pools are intentionally out of scope.

Side note found while writing this: the 1.0.11 `add-node-selectors.sh` script wrote `alloy.nodeSelector` at the top level, which the Grafana Alloy subchart silently ignores (it expects `alloy.controller.nodeSelector`). So the prior nodeSelector was likely a no-op anyway — the 1.0.12 "fix" wasn't observed as a coverage gap because the selector was never actually being applied.

## Files changed

- `charts/monitoring-logging/Chart.yaml` — `version` and `appVersion` 1.0.12 → 1.0.13
- `charts/monitoring-logging/values.yaml` — `alloy.controller.nodeSelector` block; rewritten `alloy.alloy.configMap.content` (namespace filter, `*.log` glob, `local.file_match`)
- `charts/monitoring-logging/docs/upgrade-from-1.0.12-to-1.0.13.md` — new upgrade guide

## Out of scope (follow-ups)

- `promtail.nodeSelector` and `prometheus.prometheus-node-exporter.nodeSelector` (set per-env via `add-node-selectors.sh`) have the same DaemonSet-on-one-pool issue. Worth a separate ticket.
- README is auto-generated by helm-docs; not regenerated here.

## Test plan

- [ ] `helm lint charts/monitoring-logging/` — passes (verified locally; only pre-existing minio coalesce warnings)
- [ ] `helm template charts/monitoring-logging/` — renders cleanly (verified locally)
- [ ] Deploy to dev cluster; `kubectl logs -l app.kubernetes.io/name=alloy --tail=100` shows clean startup with no River validation errors
- [ ] `kubectl get pods -l app.kubernetes.io/name=alloy -o wide` — Alloy pods only on user pool nodes
- [ ] Confirm logs from `podiumd` and `monitoring` namespaces flow to Loki; logs from other namespaces (e.g. `kube-system`) do not
- [ ] Restart a `podiumd` pod; confirm new container's logs appear in Loki within ~10s (verifies `local.file_match` glob expansion across rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)