### PR TITLE
fix(keycloak-operator): grant SM write RBAC when CRD is present

### DIFF
--- a/charts/podiumd/templates/keycloak-operator-servicemonitor-rbac.yaml
+++ b/charts/podiumd/templates/keycloak-operator-servicemonitor-rbac.yaml
@@ -62,11 +62,18 @@ subjects:
   - kind: ServiceAccount
     name: {{ $saName }}
     namespace: {{ .Release.Namespace }}
-{{- if $kcOp.enableServiceMonitor }}
+{{- if or $kcOp.enableServiceMonitor (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
 ---
 # Namespace-scoped write access — allows the operator to create and manage
 # the Keycloak ServiceMonitor in the release namespace when the CRD is present.
-# Only rendered when keycloak-operator.enableServiceMonitor: true.
+#
+# Rendered when EITHER the user explicitly enables it via
+# keycloak-operator.enableServiceMonitor: true, OR the cluster already has
+# the monitoring.coreos.com/v1/ServiceMonitor CRD installed. The latter is
+# necessary because the Keycloak Operator's KeycloakServiceMonitorDependentResource
+# controller reconciles a ServiceMonitor whenever the CRD is present, regardless
+# of chart values; without write RBAC for the `keycloak` SA, the PATCH gets a
+# 403 and the Keycloak CR stays InProgress, blocking the entire deploy.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
## Summary

- The Keycloak Operator's `KeycloakServiceMonitorDependentResource` controller reconciles a `ServiceMonitor` whenever the `monitoring.coreos.com` CRD exists in the cluster — regardless of the chart's `keycloak-operator.enableServiceMonitor` value.
- With the previous gating, a cluster that pre-installs the Prometheus Operator CRDs (e.g. the infra repo's `scripts/deploy-operators.sh` does this for `monitoring-logging`) but leaves `enableServiceMonitor: false` caused the operator's PATCH to fail with **HTTP 403**, leaving the Keycloak CR in `InProgress` and blocking the entire helm install (config jobs, realm imports, catalogi/objecttypen creation jobs all skipped).
- This change keeps the explicit `enableServiceMonitor` toggle but additionally renders the namespace-scoped `Role`/`RoleBinding` when `Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor"`. Read RBAC (the `ClusterRole`/`ClusterRoleBinding`) stays unconditional, as before.

## Repro on a fresh `jos00` deploy (today)

```
kubectl get keycloak keycloak -n podiumd -o jsonpath='{.status}'
# Conditions: Ready=Unknown, HasErrors=True
# Message: servicemonitors.monitoring.coreos.com "keycloak" is forbidden:
#   User "system:serviceaccount:podiumd:keycloak" cannot patch resource
#   "servicemonitors" in API group "monitoring.coreos.com"
```

Live workaround applied to unblock the env: `kubectl patch clusterrole podiumd-keycloak-operator-servicemonitor-view --type=json -p='[{"op":"replace","path":"/rules/0/verbs","value":["get","list","watch","create","patch","update","delete"]}]'` (intentionally on the read-only ClusterRole; the chart fix uses a Role bound to both `<release>-keycloak-operator` and `keycloak` SAs).

## Test plan

- [ ] `helm template` renders both Role + RoleBinding when the CRD exists, neither when it doesn't.
- [ ] Fresh deploy on a cluster with Prometheus Operator CRDs reaches `Keycloak Ready=True` and runs all post-install hook Jobs.
- [ ] Fresh deploy on a cluster without those CRDs is unchanged (only the read-only ClusterRole renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)