### PR TITLE
feat(mi-exports): weekly DB exports to blob storage (IN-1650/IN-1691)

### DIFF
--- a/charts/podiumd/templates/mi-export-cronjobs.yaml
+++ b/charts/podiumd/templates/mi-export-cronjobs.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.mi.enabled }}
 {{- $mi := .Values.mi }}
 {{- $root := . }}
+{{- $format := default "csv" $mi.format }}
+{{- if not (has $format (list "csv" "pgdump")) }}
+  {{- fail (printf "mi.format must be one of: csv, pgdump (got %q)" $format) }}
+{{- end }}
 
 {{- /*
   One CronJob per entry in mi.targets[]. Each entry is gated on the chart's
@@ -70,6 +74,8 @@ spec:
                   value: {{ $t.component | quote }}
                 - name: MI_SCHEMAS
                   value: {{ default (list "public") $t.schemas | join " " | quote }}
+                - name: MI_FORMAT
+                  value: {{ $format | quote }}
               envFrom:
                 - secretRef:
                     name: {{ $mi.storage.secretName | quote }}

--- a/charts/podiumd/templates/mi-export-cronjobs.yaml
+++ b/charts/podiumd/templates/mi-export-cronjobs.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.mi.enabled }}
+{{- $mi := .Values.mi }}
+{{- $root := . }}
+
+{{- /*
+  One CronJob per entry in mi.targets[]. Each entry is gated on the chart's
+  existing <component>.enabled flag, so an MI export only renders for apps
+  this chart is actively deploying. Disabling a component (or its mi target)
+  removes the corresponding CronJob.
+*/}}
+{{- range $t := $mi.targets }}
+{{- $componentValues := index $root.Values $t.component | default dict }}
+{{- $componentEnabled := dig "enabled" false $componentValues }}
+{{- $targetEnabled    := dig "enabled" true  $t }}
+{{- if and $componentEnabled $targetEnabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mi-export-{{ $t.component }}
+  labels:
+    {{- include "podiumd.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: mi-export
+    mi.podiumd.dimpact.nl/target: {{ $t.component | quote }}
+spec:
+  schedule: {{ $mi.schedule | quote }}
+  timeZone: {{ $mi.timeZone | quote }}
+  concurrencyPolicy: {{ $mi.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ $mi.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $mi.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: {{ $mi.ttlSecondsAfterFinished }}
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            {{- include "podiumd.labels" $root | nindent 12 }}
+            app.kubernetes.io/component: mi-export
+            mi.podiumd.dimpact.nl/target: {{ $t.component | quote }}
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          {{- with $mi.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: dump
+              image: {{ include "podiumd.image" $mi.image }}
+              imagePullPolicy: IfNotPresent
+              resources:
+                {{- toYaml $mi.resources | nindent 16 }}
+              securityContext:
+                # iter3-todo: bake a purpose-built image (psql installed at build time),
+                # then re-enable runAsNonRoot/runAsUser:1000 and readOnlyRootFilesystem.
+                # Iter1 needs root because tdnf install on Azure Linux requires it.
+                runAsNonRoot: false
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              env:
+                - name: MI_GEMEENTE
+                  value: {{ required "mi.gemeente is required" $mi.gemeente | quote }}
+                - name: MI_COMPONENT
+                  value: {{ $t.component | quote }}
+                - name: MI_SCHEMAS
+                  value: {{ default (list "public") $t.schemas | join " " | quote }}
+              envFrom:
+                - secretRef:
+                    name: {{ $mi.storage.secretName | quote }}
+                # The chart's per-app convention is: <component> Secret carries DB_PASSWORD
+                # (and other app secrets); <component> ConfigMap carries DB_HOST, DB_NAME,
+                # DB_USER, DB_PORT. Both default to the target's component name; override
+                # secretName/configMapName per-target only when the chart subchart key
+                # differs from the K8s resource name (e.g. opennotificaties → notificaties).
+                - secretRef:
+                    name: {{ default $t.component $t.secretName | quote }}
+                - configMapRef:
+                    name: {{ default $t.component $t.configMapName | quote }}
+              command: ["/bin/sh", "-c"]
+              args:
+                - exec /bin/bash /scripts/dump.sh
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: scripts
+              configMap:
+                name: mi-export-scripts
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/podiumd/templates/mi-export-scripts.yaml
+++ b/charts/podiumd/templates/mi-export-scripts.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.mi.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mi-export-scripts
+  labels:
+    {{- include "podiumd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mi-export
+data:
+  # One unified dump script, modeled on Maykin's bin/dump_data.sh --csv path
+  # (open-zaak, objects-api, etc.): enumerate pg_tables in the chosen schemas
+  # and \COPY each to STDOUT, streaming into a per-table blob upload.
+  dump.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    : "${AZURE_STORAGE_ACCOUNT:?must be set}"
+    : "${AZURE_STORAGE_KEY:?must be set}"
+    : "${AZURE_STORAGE_CONTAINER:?must be set}"
+    : "${MI_GEMEENTE:?must be set}"
+    : "${MI_COMPONENT:?must be set}"
+    : "${DB_HOST:?must be set}"
+    : "${DB_NAME:?must be set}"
+    : "${DB_USER:?must be set}"
+    : "${DB_PASSWORD:?must be set}"
+    DB_PORT="${DB_PORT:-5432}"
+    # Whitespace-separated list, e.g. "public" or "public flowable". Default: public.
+    MI_SCHEMAS="${MI_SCHEMAS:-public}"
+
+    TS="$(date -u +%Y%m%d-%H%M%S)"
+    log() { printf '[%s] %s\n' "$(date -u -Iseconds)" "$*"; }
+
+    # iter3-todo: image is mcr.microsoft.com/azure-cli (Azure Linux) with psql
+    # installed at runtime via tdnf; bake a purpose-built image and drop this
+    # bootstrap step (and re-enable runAsNonRoot in the CronJob securityContext).
+    if ! command -v psql >/dev/null 2>&1; then
+      log "installing postgresql client"
+      tdnf install -y --quiet postgresql >/dev/null
+    fi
+
+    psql_run() {
+      PGPASSWORD="${DB_PASSWORD}" psql \
+        --host="${DB_HOST}" --port="${DB_PORT}" \
+        --username="${DB_USER}" --dbname="${DB_NAME}" \
+        --no-psqlrc --set ON_ERROR_STOP=1 "$@"
+    }
+
+    # `az storage blob upload --file /dev/stdin` does not stream — it stats the
+    # path, gets 0, and uploads an empty blob. Stage to a temp file on the
+    # /tmp emptyDir, then upload from that file. iter3-todo: switch to azcopy
+    # `--from-to PipeBlob` once we have an image with azcopy baked in, to drop
+    # the per-table disk staging.
+    upload_stdin() {
+      local blob_name="$1"
+      local tmp
+      tmp="$(mktemp /tmp/dump.XXXXXX.csv)"
+      cat > "${tmp}"
+      az storage blob upload \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
+        --account-key  "${AZURE_STORAGE_KEY}" \
+        --container-name "${AZURE_STORAGE_CONTAINER}" \
+        --name "${blob_name}" \
+        --file "${tmp}" \
+        --overwrite \
+        --only-show-errors
+      local rc=$?
+      rm -f "${tmp}"
+      return ${rc}
+    }
+
+    list_tables() {
+      # Returns 'schema<TAB>table' lines for every base table in the requested schemas.
+      local in_clause
+      in_clause="$(printf "'%s'," ${MI_SCHEMAS})"
+      in_clause="${in_clause%,}"
+      psql_run -At -F $'\t' --command="
+        SELECT schemaname, tablename
+        FROM pg_catalog.pg_tables
+        WHERE schemaname IN (${in_clause})
+        ORDER BY schemaname, tablename
+      "
+    }
+
+    dump_one() {
+      # dump_one <schema> <table>
+      local schema="$1" table="$2" blob label
+      if [ "${schema}" = "public" ]; then label="${table}"; else label="${schema}_${table}"; fi
+      blob="${MI_GEMEENTE}/${TS}-${MI_COMPONENT}-${label}.csv"
+      log "dumping ${schema}.${table} -> ${blob}"
+      # iter3-todo: revisit gzip compression once the historical memory
+      # issue is reproduced and root-caused.
+      psql_run --command="\\COPY \"${schema}\".\"${table}\" TO STDOUT CSV HEADER" \
+        | upload_stdin "${blob}"
+    }
+
+    log "starting MI export: component=${MI_COMPONENT} schemas=${MI_SCHEMAS}"
+    rows="$(list_tables)"
+    if [ -z "${rows}" ]; then
+      log "no tables found in schemas (${MI_SCHEMAS}) of ${MI_COMPONENT} DB"
+      exit 1
+    fi
+
+    n=0
+    while IFS=$'\t' read -r schema table; do
+      [ -z "${schema}" ] && continue
+      dump_one "${schema}" "${table}"
+      n=$((n+1))
+    done <<< "${rows}"
+    log "done: ${n} table(s) exported"
+{{- end }}

--- a/charts/podiumd/templates/mi-export-scripts.yaml
+++ b/charts/podiumd/templates/mi-export-scripts.yaml
@@ -7,14 +7,18 @@ metadata:
     {{- include "podiumd.labels" . | nindent 4 }}
     app.kubernetes.io/component: mi-export
 data:
-  # Unified dump script, modeled on Maykin's bin/dump_data.sh --csv path
-  # (open-zaak, objects-api, etc.): enumerate pg_tables in the chosen schemas,
-  # \COPY each to a per-table CSV on the /tmp emptyDir, then package the whole
-  # set into one streaming tar.gz and upload as a single blob per run.
+  # Unified dump script. Two output formats, selected via MI_FORMAT:
   #
-  # Blob layout: <gemeente>/<YYMMDD>/<component>/<HHMMSS>-<component>.tar.gz
-  # Inside the tarball: one CSV per table, named <table>.csv (or <schema>_<table>.csv
-  # when the schema is not public).
+  #   csv    — modeled on Maykin's bin/dump_data.sh --csv path: enumerate
+  #            pg_tables in the chosen schemas, \COPY each to a per-table CSV
+  #            on the /tmp emptyDir, then package into one tar.gz.
+  #            Blob: <gemeente>/<YYMMDD>/<component>/<HHMMSS>-<component>.tar.gz
+  #            Inside: one CSV per table, named <table>.csv
+  #            (or <schema>_<table>.csv when the schema is not public).
+  #
+  #   pgdump — pg_dump -Fc against the chosen schemas. Single output file in
+  #            Postgres custom format (zlib-compressed, restorable via pg_restore).
+  #            Blob: <gemeente>/<YYMMDD>/<component>/<HHMMSS>-<component>.pgdump
   dump.sh: |
     #!/usr/bin/env bash
     set -euo pipefail
@@ -31,6 +35,7 @@ data:
     DB_PORT="${DB_PORT:-5432}"
     # Whitespace-separated list, e.g. "public" or "public flowable". Default: public.
     MI_SCHEMAS="${MI_SCHEMAS:-public}"
+    MI_FORMAT="${MI_FORMAT:-csv}"
 
     # One timestamp captured at script start so every table from a single run
     # lands under the same date+time path. Slicing keeps DATE_DIR and TIME_PART
@@ -40,23 +45,22 @@ data:
     TIME_PART="${TS:9:6}"  # HHMMSS
     log() { printf '[%s] %s\n' "$(date -u -Iseconds)" "$*"; }
 
-    # iter3-todo: image is mcr.microsoft.com/azure-cli (Azure Linux) with psql
-    # and tar installed at runtime via tdnf; bake a purpose-built image and
-    # drop this bootstrap step (and re-enable runAsNonRoot in the CronJob
-    # securityContext). gzip is already present in the base image.
+    # iter3-todo: image is mcr.microsoft.com/azure-cli (Azure Linux) with the
+    # postgresql tooling and tar installed at runtime via tdnf; bake a
+    # purpose-built image and drop this bootstrap step (and re-enable
+    # runAsNonRoot in the CronJob securityContext). gzip is already present in
+    # the base image. The `postgresql` package supplies both psql and pg_dump.
     needs=()
-    command -v psql >/dev/null 2>&1 || needs+=(postgresql)
-    command -v tar  >/dev/null 2>&1 || needs+=(tar)
+    command -v psql    >/dev/null 2>&1 || needs+=(postgresql)
+    command -v pg_dump >/dev/null 2>&1 || needs+=(postgresql)
+    command -v tar     >/dev/null 2>&1 || needs+=(tar)
     if [ "${#needs[@]}" -gt 0 ]; then
-      log "installing: ${needs[*]}"
-      tdnf install -y --quiet "${needs[@]}" >/dev/null
+      # Dedupe: a single `postgresql` install gives us psql + pg_dump.
+      uniq_needs=$(printf '%s\n' "${needs[@]}" | sort -u)
+      log "installing: ${uniq_needs}"
+      # shellcheck disable=SC2086
+      tdnf install -y --quiet ${uniq_needs} >/dev/null
     fi
-
-    # Per-run scratch area on the /tmp emptyDir. Holds CSVs while we accumulate
-    # them, plus the final tar.gz. Both are wiped on exit (success or failure).
-    WORK="$(mktemp -d /tmp/mi-csv.XXXXXX)"
-    TARBALL="$(mktemp -u -p /tmp mi-XXXXXX.tar.gz)"
-    trap 'rm -rf "${WORK}" "${TARBALL}"' EXIT
 
     psql_run() {
       PGPASSWORD="${DB_PASSWORD}" psql \
@@ -65,60 +69,107 @@ data:
         --no-psqlrc --set ON_ERROR_STOP=1 "$@"
     }
 
-    list_tables() {
-      # Returns 'schema<TAB>table' lines for every base table in the requested schemas.
-      local in_clause
-      in_clause="$(printf "'%s'," ${MI_SCHEMAS})"
-      in_clause="${in_clause%,}"
-      psql_run -At -F $'\t' --command="
-        SELECT schemaname, tablename
-        FROM pg_catalog.pg_tables
-        WHERE schemaname IN (${in_clause})
-        ORDER BY schemaname, tablename
-      "
+    upload_blob() {
+      # upload_blob <local-file> <blob-path>
+      local file="$1" blob="$2" size
+      size="$(stat -c%s "${file}" 2>/dev/null || stat -f%z "${file}")"
+      log "uploading ${blob} (${size} bytes)"
+      az storage blob upload \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
+        --account-key  "${AZURE_STORAGE_KEY}" \
+        --container-name "${AZURE_STORAGE_CONTAINER}" \
+        --name "${blob}" \
+        --file "${file}" \
+        --overwrite \
+        --only-show-errors >/dev/null
     }
 
-    dump_one_to_disk() {
-      # dump_one_to_disk <schema> <table>  → ${WORK}/<label>.csv
-      # label drops the schema prefix for public (same convention as before).
-      local schema="$1" table="$2" label
-      if [ "${schema}" = "public" ]; then label="${table}"; else label="${schema}_${table}"; fi
-      log "dumping ${schema}.${table} -> ${label}.csv"
-      psql_run --command="\\COPY \"${schema}\".\"${table}\" TO STDOUT CSV HEADER" \
-        > "${WORK}/${label}.csv"
-    }
+    log "starting MI export: component=${MI_COMPONENT} schemas=${MI_SCHEMAS} format=${MI_FORMAT}"
 
-    log "starting MI export: component=${MI_COMPONENT} schemas=${MI_SCHEMAS}"
-    rows="$(list_tables)"
-    if [ -z "${rows}" ]; then
-      log "no tables found in schemas (${MI_SCHEMAS}) of ${MI_COMPONENT} DB"
-      exit 1
-    fi
+    case "${MI_FORMAT}" in
+      csv)
+        # Per-run scratch area on the /tmp emptyDir. Holds CSVs while we
+        # accumulate them, plus the final tar.gz. Both are wiped on exit.
+        WORK="$(mktemp -d /tmp/mi-csv.XXXXXX)"
+        TARBALL="$(mktemp -u -p /tmp mi-XXXXXX.tar.gz)"
+        trap 'rm -rf "${WORK}" "${TARBALL}"' EXIT
 
-    n=0
-    while IFS=$'\t' read -r schema table; do
-      [ -z "${schema}" ] && continue
-      dump_one_to_disk "${schema}" "${table}"
-      n=$((n+1))
-    done <<< "${rows}"
+        list_tables() {
+          # Returns 'schema<TAB>table' lines for every base table in the requested schemas.
+          local in_clause
+          in_clause="$(printf "'%s'," ${MI_SCHEMAS})"
+          in_clause="${in_clause%,}"
+          psql_run -At -F $'\t' --command="
+            SELECT schemaname, tablename
+            FROM pg_catalog.pg_tables
+            WHERE schemaname IN (${in_clause})
+            ORDER BY schemaname, tablename
+          "
+        }
 
-    # Package every CSV into one streaming tar.gz. gzip's deflate window is
-    # 32 KiB regardless of input size — memory stays bounded at ~256 KiB
-    # whether we package 5 tables or 5,000.
-    log "packaging ${n} CSV(s) into ${MI_COMPONENT}.tar.gz"
-    tar -czf "${TARBALL}" -C "${WORK}" .
+        dump_one_to_disk() {
+          # dump_one_to_disk <schema> <table>  → ${WORK}/<label>.csv
+          # label drops the schema prefix for public (same convention as before).
+          local schema="$1" table="$2" label
+          if [ "${schema}" = "public" ]; then label="${table}"; else label="${schema}_${table}"; fi
+          log "dumping ${schema}.${table} -> ${label}.csv"
+          psql_run --command="\\COPY \"${schema}\".\"${table}\" TO STDOUT CSV HEADER" \
+            > "${WORK}/${label}.csv"
+        }
 
-    BLOB="${MI_GEMEENTE}/${DATE_DIR}/${MI_COMPONENT}/${TIME_PART}-${MI_COMPONENT}.tar.gz"
-    SIZE="$(stat -c%s "${TARBALL}" 2>/dev/null || stat -f%z "${TARBALL}")"
-    log "uploading ${BLOB} (${SIZE} bytes)"
-    az storage blob upload \
-      --account-name "${AZURE_STORAGE_ACCOUNT}" \
-      --account-key  "${AZURE_STORAGE_KEY}" \
-      --container-name "${AZURE_STORAGE_CONTAINER}" \
-      --name "${BLOB}" \
-      --file "${TARBALL}" \
-      --overwrite \
-      --only-show-errors >/dev/null
+        rows="$(list_tables)"
+        if [ -z "${rows}" ]; then
+          log "no tables found in schemas (${MI_SCHEMAS}) of ${MI_COMPONENT} DB"
+          exit 1
+        fi
 
-    log "done: ${n} table(s) packaged in ${BLOB}"
+        n=0
+        while IFS=$'\t' read -r schema table; do
+          [ -z "${schema}" ] && continue
+          dump_one_to_disk "${schema}" "${table}"
+          n=$((n+1))
+        done <<< "${rows}"
+
+        # gzip's deflate window is 32 KiB regardless of input size — memory
+        # stays bounded at ~256 KiB whether we package 5 tables or 5,000.
+        log "packaging ${n} CSV(s) into ${MI_COMPONENT}.tar.gz"
+        tar -czf "${TARBALL}" -C "${WORK}" .
+
+        BLOB="${MI_GEMEENTE}/${DATE_DIR}/${MI_COMPONENT}/${TIME_PART}-${MI_COMPONENT}.tar.gz"
+        upload_blob "${TARBALL}" "${BLOB}"
+        log "done: ${n} table(s) packaged in ${BLOB}"
+        ;;
+
+      pgdump)
+        # Single pg_dump in custom format (-Fc) — zlib-compressed, restorable
+        # with pg_restore, includes schema + data + ownership/privileges.
+        # One -n flag per requested schema; tables outside those schemas are
+        # excluded (matches the csv path's filtering).
+        DUMPFILE="$(mktemp -u -p /tmp mi-XXXXXX.pgdump)"
+        trap 'rm -f "${DUMPFILE}"' EXIT
+
+        schema_args=()
+        for s in ${MI_SCHEMAS}; do
+          schema_args+=(-n "${s}")
+        done
+
+        log "running pg_dump -Fc on ${DB_NAME} (schemas: ${MI_SCHEMAS})"
+        PGPASSWORD="${DB_PASSWORD}" pg_dump \
+          --host="${DB_HOST}" --port="${DB_PORT}" \
+          --username="${DB_USER}" --dbname="${DB_NAME}" \
+          --format=custom \
+          --no-owner --no-privileges \
+          "${schema_args[@]}" \
+          --file="${DUMPFILE}"
+
+        BLOB="${MI_GEMEENTE}/${DATE_DIR}/${MI_COMPONENT}/${TIME_PART}-${MI_COMPONENT}.pgdump"
+        upload_blob "${DUMPFILE}" "${BLOB}"
+        log "done: pg_dump uploaded to ${BLOB}"
+        ;;
+
+      *)
+        log "unsupported MI_FORMAT='${MI_FORMAT}' (expected csv or pgdump)"
+        exit 2
+        ;;
+    esac
 {{- end }}

--- a/charts/podiumd/templates/mi-export-scripts.yaml
+++ b/charts/podiumd/templates/mi-export-scripts.yaml
@@ -7,9 +7,14 @@ metadata:
     {{- include "podiumd.labels" . | nindent 4 }}
     app.kubernetes.io/component: mi-export
 data:
-  # One unified dump script, modeled on Maykin's bin/dump_data.sh --csv path
-  # (open-zaak, objects-api, etc.): enumerate pg_tables in the chosen schemas
-  # and \COPY each to STDOUT, streaming into a per-table blob upload.
+  # Unified dump script, modeled on Maykin's bin/dump_data.sh --csv path
+  # (open-zaak, objects-api, etc.): enumerate pg_tables in the chosen schemas,
+  # \COPY each to a per-table CSV on the /tmp emptyDir, then package the whole
+  # set into one streaming tar.gz and upload as a single blob per run.
+  #
+  # Blob layout: <gemeente>/<YYMMDD>/<component>/<HHMMSS>-<component>.tar.gz
+  # Inside the tarball: one CSV per table, named <table>.csv (or <schema>_<table>.csv
+  # when the schema is not public).
   dump.sh: |
     #!/usr/bin/env bash
     set -euo pipefail
@@ -36,41 +41,28 @@ data:
     log() { printf '[%s] %s\n' "$(date -u -Iseconds)" "$*"; }
 
     # iter3-todo: image is mcr.microsoft.com/azure-cli (Azure Linux) with psql
-    # installed at runtime via tdnf; bake a purpose-built image and drop this
-    # bootstrap step (and re-enable runAsNonRoot in the CronJob securityContext).
-    if ! command -v psql >/dev/null 2>&1; then
-      log "installing postgresql client"
-      tdnf install -y --quiet postgresql >/dev/null
+    # and tar installed at runtime via tdnf; bake a purpose-built image and
+    # drop this bootstrap step (and re-enable runAsNonRoot in the CronJob
+    # securityContext). gzip is already present in the base image.
+    needs=()
+    command -v psql >/dev/null 2>&1 || needs+=(postgresql)
+    command -v tar  >/dev/null 2>&1 || needs+=(tar)
+    if [ "${#needs[@]}" -gt 0 ]; then
+      log "installing: ${needs[*]}"
+      tdnf install -y --quiet "${needs[@]}" >/dev/null
     fi
+
+    # Per-run scratch area on the /tmp emptyDir. Holds CSVs while we accumulate
+    # them, plus the final tar.gz. Both are wiped on exit (success or failure).
+    WORK="$(mktemp -d /tmp/mi-csv.XXXXXX)"
+    TARBALL="$(mktemp -u -p /tmp mi-XXXXXX.tar.gz)"
+    trap 'rm -rf "${WORK}" "${TARBALL}"' EXIT
 
     psql_run() {
       PGPASSWORD="${DB_PASSWORD}" psql \
         --host="${DB_HOST}" --port="${DB_PORT}" \
         --username="${DB_USER}" --dbname="${DB_NAME}" \
         --no-psqlrc --set ON_ERROR_STOP=1 "$@"
-    }
-
-    # `az storage blob upload --file /dev/stdin` does not stream — it stats the
-    # path, gets 0, and uploads an empty blob. Stage to a temp file on the
-    # /tmp emptyDir, then upload from that file. iter3-todo: switch to azcopy
-    # `--from-to PipeBlob` once we have an image with azcopy baked in, to drop
-    # the per-table disk staging.
-    upload_stdin() {
-      local blob_name="$1"
-      local tmp
-      tmp="$(mktemp /tmp/dump.XXXXXX.csv)"
-      cat > "${tmp}"
-      az storage blob upload \
-        --account-name "${AZURE_STORAGE_ACCOUNT}" \
-        --account-key  "${AZURE_STORAGE_KEY}" \
-        --container-name "${AZURE_STORAGE_CONTAINER}" \
-        --name "${blob_name}" \
-        --file "${tmp}" \
-        --overwrite \
-        --only-show-errors
-      local rc=$?
-      rm -f "${tmp}"
-      return ${rc}
     }
 
     list_tables() {
@@ -86,19 +78,14 @@ data:
       "
     }
 
-    dump_one() {
-      # dump_one <schema> <table>
-      # Blob path: <gemeente>/<YYMMDD>/<component>/<HHMMSS>-<schema>_<table>.csv
-      # (label drops the schema prefix when schema=public — same convention
-      # as before).
-      local schema="$1" table="$2" blob label
+    dump_one_to_disk() {
+      # dump_one_to_disk <schema> <table>  → ${WORK}/<label>.csv
+      # label drops the schema prefix for public (same convention as before).
+      local schema="$1" table="$2" label
       if [ "${schema}" = "public" ]; then label="${table}"; else label="${schema}_${table}"; fi
-      blob="${MI_GEMEENTE}/${DATE_DIR}/${MI_COMPONENT}/${TIME_PART}-${label}.csv"
-      log "dumping ${schema}.${table} -> ${blob}"
-      # iter3-todo: revisit gzip compression once the historical memory
-      # issue is reproduced and root-caused.
+      log "dumping ${schema}.${table} -> ${label}.csv"
       psql_run --command="\\COPY \"${schema}\".\"${table}\" TO STDOUT CSV HEADER" \
-        | upload_stdin "${blob}"
+        > "${WORK}/${label}.csv"
     }
 
     log "starting MI export: component=${MI_COMPONENT} schemas=${MI_SCHEMAS}"
@@ -111,8 +98,27 @@ data:
     n=0
     while IFS=$'\t' read -r schema table; do
       [ -z "${schema}" ] && continue
-      dump_one "${schema}" "${table}"
+      dump_one_to_disk "${schema}" "${table}"
       n=$((n+1))
     done <<< "${rows}"
-    log "done: ${n} table(s) exported"
+
+    # Package every CSV into one streaming tar.gz. gzip's deflate window is
+    # 32 KiB regardless of input size — memory stays bounded at ~256 KiB
+    # whether we package 5 tables or 5,000.
+    log "packaging ${n} CSV(s) into ${MI_COMPONENT}.tar.gz"
+    tar -czf "${TARBALL}" -C "${WORK}" .
+
+    BLOB="${MI_GEMEENTE}/${DATE_DIR}/${MI_COMPONENT}/${TIME_PART}-${MI_COMPONENT}.tar.gz"
+    SIZE="$(stat -c%s "${TARBALL}" 2>/dev/null || stat -f%z "${TARBALL}")"
+    log "uploading ${BLOB} (${SIZE} bytes)"
+    az storage blob upload \
+      --account-name "${AZURE_STORAGE_ACCOUNT}" \
+      --account-key  "${AZURE_STORAGE_KEY}" \
+      --container-name "${AZURE_STORAGE_CONTAINER}" \
+      --name "${BLOB}" \
+      --file "${TARBALL}" \
+      --overwrite \
+      --only-show-errors >/dev/null
+
+    log "done: ${n} table(s) packaged in ${BLOB}"
 {{- end }}

--- a/charts/podiumd/templates/mi-export-scripts.yaml
+++ b/charts/podiumd/templates/mi-export-scripts.yaml
@@ -27,7 +27,12 @@ data:
     # Whitespace-separated list, e.g. "public" or "public flowable". Default: public.
     MI_SCHEMAS="${MI_SCHEMAS:-public}"
 
+    # One timestamp captured at script start so every table from a single run
+    # lands under the same date+time path. Slicing keeps DATE_DIR and TIME_PART
+    # consistent (no second-boundary skew between separate `date` calls).
     TS="$(date -u +%Y%m%d-%H%M%S)"
+    DATE_DIR="${TS:2:6}"   # YYMMDD
+    TIME_PART="${TS:9:6}"  # HHMMSS
     log() { printf '[%s] %s\n' "$(date -u -Iseconds)" "$*"; }
 
     # iter3-todo: image is mcr.microsoft.com/azure-cli (Azure Linux) with psql
@@ -83,9 +88,12 @@ data:
 
     dump_one() {
       # dump_one <schema> <table>
+      # Blob path: <gemeente>/<YYMMDD>/<component>/<HHMMSS>-<schema>_<table>.csv
+      # (label drops the schema prefix when schema=public — same convention
+      # as before).
       local schema="$1" table="$2" blob label
       if [ "${schema}" = "public" ]; then label="${table}"; else label="${schema}_${table}"; fi
-      blob="${MI_GEMEENTE}/${TS}-${MI_COMPONENT}-${label}.csv"
+      blob="${MI_GEMEENTE}/${DATE_DIR}/${MI_COMPONENT}/${TIME_PART}-${label}.csv"
       log "dumping ${schema}.${table} -> ${blob}"
       # iter3-todo: revisit gzip compression once the historical memory
       # issue is reproduced and root-caused.

--- a/charts/podiumd/templates/redis-ha-pre-delete.yaml
+++ b/charts/podiumd/templates/redis-ha-pre-delete.yaml
@@ -1,0 +1,121 @@
+{{- $redisOperator := index .Values "redis-operator" }}
+{{- if $redisOperator.enabled }}
+{{/*
+  Pre-delete Helm hook: explicitly delete the RedisReplication CR while the
+  redis-operator is still running, so its finalizer (`redisReplicationFinalizer`)
+  can be processed before helm tears down the operator's Deployment. Without
+  this, helm uninstall completes the regular resource delete in an undefined
+  order; if the operator goes first, the CR keeps its finalizer and namespace
+  termination gets stuck.
+
+  This is an iter1-style patch. The proper long-term fix is to extract the
+  redis-operator (and keycloak-operator) into their own helm releases the way
+  eck-operator already is — see iter3 backlog item on operator extraction.
+*/}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redis-ha-pre-delete
+  labels:
+    {{- include "podiumd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: redis-ha-pre-delete
+  labels:
+    {{- include "podiumd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["redis.redis.opstreelabs.in"]
+    resources: ["redisreplications"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: redis-ha-pre-delete
+  labels:
+    {{- include "podiumd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: redis-ha-pre-delete
+subjects:
+  - kind: ServiceAccount
+    name: redis-ha-pre-delete
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redis-ha-pre-delete
+  labels:
+    {{- include "podiumd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "podiumd.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: redis-ha-pre-delete
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      containers:
+        - name: drain-redis-ha
+          image: docker.io/alpine/k8s:1.33.10
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              NS="{{ .Release.Namespace }}"
+              if ! kubectl -n "$NS" get redisreplication redis-ha >/dev/null 2>&1; then
+                echo "redisreplication/redis-ha not present — nothing to drain"
+                exit 0
+              fi
+              echo "deleting redisreplication/redis-ha; redis-operator will process its finalizer..."
+              kubectl -n "$NS" delete redisreplication redis-ha \
+                --wait=true --timeout=90s --ignore-not-found
+              echo "done"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3350,6 +3350,11 @@ mi:
   enabled: false
   # Top-level path prefix under the storage container — keeps each gemeente's exports isolated.
   gemeente: ""
+  # Output format. One of:
+  #   csv    — per-table \COPY → tar.gz of CSVs (one CSV per table inside the tarball).
+  #   pgdump — pg_dump -Fc (custom format, zlib-compressed, restorable via pg_restore).
+  # All targets in an environment use the same format; per-target overrides are not supported.
+  format: csv
   schedule: "0 2 * * 0"
   timeZone: "Europe/Amsterdam"
   concurrencyPolicy: Forbid

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3335,11 +3335,29 @@ apisix:
         secretName: apisix-admin-credentials
 
 # Management Information (MI) data exports — IN-1650 / IN-1691.
-# Iter1: weekly dump-to-blob via az CLI. No SFTP, no compression, no consumer-side portal yet.
-# One unified script (modeled on Maykin's bin/dump_data.sh --csv) is used for every target;
-# each entry in mi.targets[] renders one CronJob, gated on the chart's existing
-# <component>.enabled flag — so a CronJob only renders for an app this chart is actively
-# deploying ("dump apps that are deployed and running").
+#
+# OPT-IN FEATURE — DISABLED BY DEFAULT (`mi.enabled: false`).
+#
+# Before enabling in any environment, the cluster MUST already have:
+#   1. An Azure Blob Storage container available to the chart (convention:
+#      an `mi-exports` container on the env's standard storage account).
+#   2. The storage credentials materialised as a K8s Secret named
+#      `mi-export-storage` in the `podiumd` namespace, with three keys:
+#      AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY, AZURE_STORAGE_CONTAINER.
+#
+# If those prerequisites aren't in place, the CronJobs will render but their
+# pods fail on the first run with "AZURE_STORAGE_KEY: must be set". Enabling
+# this feature is a one-line toggle here — the cloud/infra side is the work.
+#
+# Full activation, infra prerequisites (incl. Terraform notes for external
+# hosting providers), validation, and troubleshooting:
+#   → docs/podiumd/mi-exports.md
+#
+# Iter1: weekly dump-to-blob via az CLI. No SFTP, no consumer-side portal yet.
+# One unified script (modeled on Maykin's bin/dump_data.sh --csv) is used for
+# every target; each entry in mi.targets[] renders one CronJob, gated on the
+# chart's existing <component>.enabled flag — so a CronJob only renders for an
+# app this chart is actively deploying.
 #
 # Per-target DB credentials follow the chart's existing per-app convention:
 #   - <secretName> Secret    — must contain DB_PASSWORD (plus other app secrets is fine)
@@ -3347,6 +3365,8 @@ apisix:
 # Both default to the target's `component`. Override only when the chart subchart key
 # differs from the K8s resource name (e.g. opennotificaties → notificaties resources).
 mi:
+  # Disabled by default. Set to true ONLY after the cloud prerequisites above
+  # are in place and Secret/mi-export-storage exists in the podiumd namespace.
   enabled: false
   # Top-level path prefix under the storage container — keeps each gemeente's exports isolated.
   gemeente: ""

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3333,3 +3333,63 @@ apisix:
       # `secretName` to point at your own Secret containing `admin` + `viewer`.
       credentials:
         secretName: apisix-admin-credentials
+
+# Management Information (MI) data exports — IN-1650 / IN-1691.
+# Iter1: weekly dump-to-blob via az CLI. No SFTP, no compression, no consumer-side portal yet.
+# One unified script (modeled on Maykin's bin/dump_data.sh --csv) is used for every target;
+# each entry in mi.targets[] renders one CronJob, gated on the chart's existing
+# <component>.enabled flag — so a CronJob only renders for an app this chart is actively
+# deploying ("dump apps that are deployed and running").
+#
+# Per-target DB credentials follow the chart's existing per-app convention:
+#   - <secretName> Secret    — must contain DB_PASSWORD (plus other app secrets is fine)
+#   - <configMapName> CM     — must contain DB_HOST, DB_NAME, DB_USER (DB_PORT optional)
+# Both default to the target's `component`. Override only when the chart subchart key
+# differs from the K8s resource name (e.g. opennotificaties → notificaties resources).
+mi:
+  enabled: false
+  # Top-level path prefix under the storage container — keeps each gemeente's exports isolated.
+  gemeente: ""
+  schedule: "0 2 * * 0"
+  timeZone: "Europe/Amsterdam"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  ttlSecondsAfterFinished: 86400
+  image:
+    registry: "mcr.microsoft.com"
+    repository: azure-cli
+    tag: "2.71.0"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  nodeSelector: {}
+  storage:
+    # K8s Secret expected to contain envvars: AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY, AZURE_STORAGE_CONTAINER.
+    secretName: mi-export-storage
+  # Default target list — every Postgres-backed app this chart can deploy. A target only
+  # renders a CronJob when the chart's <component>.enabled is true. Per-target `enabled`
+  # is layered on top for ad-hoc opt-out. `schemas` defaults to ["public"].
+  targets:
+    - component: openzaak
+    - component: opennotificaties
+      # Chart subchart is "opennotificaties" but its K8s resources are named "notificaties".
+      secretName: notificaties
+      configMapName: notificaties
+    - component: objecten
+    - component: objecttypen
+    - component: openarchiefbeheer
+    - component: openklant
+    - component: openformulieren
+    - component: openinwoner
+    - component: referentielijsten
+    - component: openbeheer
+    - component: zac
+      schemas: ["flowable"]
+    - component: ita
+    - component: kiss
+    - component: pabc

--- a/docs/podiumd/README.md
+++ b/docs/podiumd/README.md
@@ -64,3 +64,10 @@ Zie voor architectuur context diagram van Open Formulieren de [Open Formulieren 
 
 ### Contact (KISS)
 Zie voor architectuur context diagram van Contact (KISS) de [Contact documentatie](./contact.md).
+
+## Operationele functionaliteit
+
+### MI exports — wekelijkse database dumps naar blob storage
+Wekelijkse exports van alle Postgres-componenten naar Azure Blob Storage (CSV of `pg_dump`), per gemeente.
+Voor activatie, infra-prerequisites (incl. Terraform-snippet voor externe hosting), en troubleshooting:
+zie [MI exports documentatie](./mi-exports.md).

--- a/docs/podiumd/mi-exports.md
+++ b/docs/podiumd/mi-exports.md
@@ -195,64 +195,15 @@ The Terraform in `ICATT-Menselijk-Digitaal/podiumd-infra` is **only for Dimpact'
 
 ### What the hosting provider must add
 
-Three resources, in their existing per-env Terraform that already provisions the storage account and Key Vault:
+The cloud-side prerequisites in [§ Cloud prerequisites](#1-cloud-prerequisites-once-per-env) — `mi-exports` blob container on the existing per-env standard SA, the SA primary key stored in the base Key Vault as `mi-export-storage-<env>`, and the cluster-side `Secret/mi-export-storage` materialised before the chart is installed.
 
-```hcl
-# 1. Container on the existing standard SA
-resource "azurerm_storage_container" "mi_exports" {
-  name                  = "mi-exports"
-  storage_account_name  = azurerm_storage_account.podiumd_env.name
-  container_access_type = "private"
-}
+For SSC Twente's hosted environments, the Terraform module that already provisions the storage account and Key Vault is in `dev.azure.com/ssctwente/_git/ExternalsPodiumD`. The corresponding changes there land in branch `feature/IN-1691-mi-exports-storage` (matching the Jira ticket [IN-1691](https://dimpact.atlassian.net/browse/IN-1691)) and add:
 
-# 2. SA primary key in KV (read by the deploy pipeline)
-resource "azurerm_key_vault_secret" "mi_export_storage" {
-  name         = "mi-export-storage-${var.env_name}"
-  value        = azurerm_storage_account.podiumd_env.primary_access_key
-  key_vault_id = azurerm_key_vault.base.id
+1. The `mi-exports` blob container resource on the existing per-env SA.
+2. A `keyvault_secret` for the SA primary key, named `mi-export-storage-<env>`.
+3. A pipeline step that reads that KV secret at deploy time and creates the in-cluster `Secret/mi-export-storage` in the `podiumd` namespace before the helm install runs.
 
-  # Optional: rotate when SA key rotates
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# 3. (Optional but recommended) Lifecycle policy on the container
-#    Move blobs to Cool tier after 30d; delete after the gemeente's retention period.
-resource "azurerm_storage_management_policy" "mi_exports_lifecycle" {
-  storage_account_id = azurerm_storage_account.podiumd_env.id
-
-  rule {
-    name    = "mi-exports-tiering"
-    enabled = true
-    filters {
-      blob_types   = ["blockBlob"]
-      prefix_match = ["mi-exports/"]
-    }
-    actions {
-      base_blob {
-        tier_to_cool_after_days_since_modification_greater_than    = 30
-        tier_to_archive_after_days_since_modification_greater_than = 365
-        # delete_after_days_since_modification_greater_than = <set per gemeente policy>
-      }
-    }
-  }
-}
-```
-
-After the next deploy, materialise the cluster-side Secret:
-
-```bash
-SA_KEY=$(az keyvault secret show --vault-name <base-kv-name> \
-           --name mi-export-storage-<env> --query value -o tsv)
-
-kubectl -n podiumd create secret generic mi-export-storage \
-  --from-literal=AZURE_STORAGE_ACCOUNT=podiumd<env>st \
-  --from-literal=AZURE_STORAGE_KEY="${SA_KEY}" \
-  --from-literal=AZURE_STORAGE_CONTAINER=mi-exports
-```
-
-This step is one-shot per env, ideally automated as part of the deploy pipeline (the test/dev side has `scripts/sync-mi-export-secret.sh` for the same purpose; production providers can fold the same logic into their own pipeline).
+The chart itself is hosting-provider-agnostic — it only needs the three envvars in `Secret/mi-export-storage` to be present at install time. **Any** provisioning approach that delivers that secret with the right values works.
 
 ### What the hosting provider does *not* need
 

--- a/docs/podiumd/mi-exports.md
+++ b/docs/podiumd/mi-exports.md
@@ -1,0 +1,323 @@
+# MI exports — weekly database dumps to blob storage
+
+Weekly Management Information (MI) data exports of every Postgres-backed component the PodiumD chart deploys, written directly to Azure Blob Storage. Designed for downstream consumers (gemeentes, analytics teams) that need a regular snapshot of the operational data.
+
+> Jira: [IN-1650](https://dimpact.atlassian.net/browse/IN-1650) (epic) / [IN-1691](https://dimpact.atlassian.net/browse/IN-1691) (iteration 1).
+
+## Audience
+
+Two readers:
+- **PodiumD operators** running the chart in any environment — to enable, configure, validate and consume exports.
+- **External hosting providers** who run PodiumD in production via their own Terraform — to see what cloud-side prerequisites the chart needs.
+
+Test/dev infra in `ICATT-Menselijk-Digitaal/podiumd-infra` provisions these prerequisites for our own jim00/jos00/etc. clusters. Production-hosted environments must replicate the same shape using their own Terraform module — see [§ Production / external hosting](#production--external-hosting).
+
+## How it works
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                       AKS cluster — namespace: podiumd                        │
+│                                                                              │
+│   ┌─────────────────────────┐     ┌──────────────────────────────────────┐  │
+│   │  CronJob                │     │  Postgres (flexible-server)          │  │
+│   │  mi-export-<component>  │ ──► │  database: <component>               │  │
+│   │  (one per enabled       │     │                                      │  │
+│   │   Postgres component)   │     └──────────────────────────────────────┘  │
+│   │                         │                                                │
+│   │  schedule: 0 2 * * 0    │     ┌──────────────────────────────────────┐  │
+│   │  (Sun 02:00 NL time)    │ ──► │  K8s Secret: mi-export-storage       │  │
+│   │                         │     │  (SA name + key + container name)    │  │
+│   │  envFrom:               │     └────────────────┬─────────────────────┘  │
+│   │   - mi-export-storage   │                      │                         │
+│   │   - <component> Secret  │                      ▼                         │
+│   │   - <component> CM      │     ┌──────────────────────────────────────┐  │
+│   │                         │     │  Azure Storage Account               │  │
+│   │  ConfigMap:             │     │  podiumd<env>st                      │  │
+│   │   mi-export-scripts     │     │                                      │  │
+│   │   (dump.sh)             │ ──► │  Container: mi-exports               │  │
+│   │                         │     │   <gemeente>/<YYMMDD>/<component>/   │  │
+│   └─────────────────────────┘     │     <HHMMSS>-<component>.tar.gz      │  │
+│                                   │     (or .pgdump)                     │  │
+│                                   └──────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Each CronJob:
+1. Reads its target component's existing `<component>` Secret + ConfigMap (DB host, port, name, user, password — same secrets the app pods consume).
+2. Reads the env's storage credentials from the K8s `Secret/mi-export-storage` (SA name, SA key, container name).
+3. Runs `dump.sh` in the chart's `mi-export-scripts` ConfigMap.
+4. Writes the result as a single blob.
+
+## Output format
+
+Selected env-wide via `mi.format`. **All targets in a given environment use the same format** — there is no per-target override.
+
+| `mi.format` | Tool | Output | Use case |
+|---|---|---|---|
+| `csv` *(default)* | `psql \COPY` per table | One `.tar.gz` per component, containing one CSV per table | Analytics consumers (Excel, pandas, ingest pipelines) |
+| `pgdump` | `pg_dump -Fc --no-owner --no-privileges` per database | One `.pgdump` per component (custom format, zlib-compressed) | DR / cluster migration / point-in-time `pg_restore` |
+
+Both formats honour `mi.targets[].schemas` (default `["public"]`; `zac` overrides to `["flowable"]`).
+
+### Blob layout
+
+```
+<container>/<gemeente>/<YYMMDD>/<component>/<HHMMSS>-<component>.<ext>
+```
+
+A single timestamp is captured at script start, so every blob from one CronJob run shares the same `<HHMMSS>` prefix and lands under the same date directory. Examples:
+
+```
+mi-exports/jim00/260507/openzaak/095048-openzaak.tar.gz
+mi-exports/jim00/260507/openzaak/095048-openzaak.pgdump
+mi-exports/jim00/260507/objecten/091200-objecten.tar.gz
+```
+
+## Activation in an environment
+
+### 1. Cloud prerequisites (once per env)
+
+Before enabling the chart feature, the env's cloud must already have:
+
+- A storage container named **`mi-exports`** in the env's standard storage account (`podiumd<env>st`). No new SA is required; **do not** create a dedicated SA.
+- The SA's primary access key stored in the base Key Vault as a secret named **`mi-export-storage-<env>`**. The chart uses storage-account-key auth, **not** workload identity (decision recorded in [§ Why SA keys, not workload identity](#why-sa-keys-not-workload-identity)).
+- A K8s `Secret/mi-export-storage` in the `podiumd` namespace with three keys:
+  - `AZURE_STORAGE_ACCOUNT` (e.g. `podiumdjim00st`)
+  - `AZURE_STORAGE_KEY` (the value from KV)
+  - `AZURE_STORAGE_CONTAINER` (e.g. `mi-exports`)
+
+For test/dev envs (jim00, jos00, …): the `podiumd-infra` repo ships a script `scripts/sync-mi-export-secret.sh` that reads the KV secret and creates the K8s Secret. Run it once after a fresh app install.
+
+For production-hosted envs: see [§ Production / external hosting](#production--external-hosting).
+
+### 2. Enable in `values-<env>.yml`
+
+Minimum:
+
+```yaml
+mi:
+  enabled: true
+  gemeente: <env-name>   # used as the top-level path prefix in the blob layout
+```
+
+Defaults: weekly schedule (Sunday 02:00 Europe/Amsterdam), `csv` format, all 14 default targets. A target only renders a CronJob when the corresponding `<component>.enabled` is `true` elsewhere in the env's values, so disabling a component automatically removes its export.
+
+To switch the env to full database dumps:
+
+```yaml
+mi:
+  enabled: true
+  gemeente: <env-name>
+  format: pgdump
+```
+
+Other knobs (chart defaults shown):
+
+```yaml
+mi:
+  enabled: true
+  gemeente: <env-name>
+  format: csv                       # csv | pgdump
+  schedule: "0 2 * * 0"             # weekly Sun 02:00
+  timeZone: "Europe/Amsterdam"
+  concurrencyPolicy: Forbid         # don't overlap runs
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  ttlSecondsAfterFinished: 86400    # auto-clean Job + pod after 24h
+  storage:
+    secretName: mi-export-storage   # name of the K8s Secret
+```
+
+### 3. Trim or override the target list (optional)
+
+The chart's default `mi.targets[]` covers all 14 Postgres-backed components. You typically don't need to touch it — let `<component>.enabled` drive what's exported. If you need to override (e.g. override schemas for a custom component):
+
+```yaml
+mi:
+  targets:
+    - component: openzaak
+    - component: zac
+      schemas: ["flowable"]    # zac uses Flowable schema, not public
+    - component: openklant
+      enabled: false           # ad-hoc opt-out for this env only
+    - component: opennotificaties
+      secretName: notificaties # override when subchart key ≠ resource name
+      configMapName: notificaties
+```
+
+### 4. Validation
+
+After the next chart apply:
+
+```bash
+# Should list one CronJob per enabled component
+kubectl -n podiumd get cronjob -l app.kubernetes.io/component=mi-export
+
+# Trigger an out-of-schedule run for one component
+kubectl -n podiumd create job --from=cronjob/mi-export-openzaak mi-test-now
+
+# Watch
+kubectl -n podiumd logs -l job-name=mi-test-now -f --tail=50
+
+# Verify the blob landed
+SA_KEY=$(az keyvault secret show --vault-name <base-kv-name> \
+           --name mi-export-storage-<env> --query value -o tsv)
+az storage blob list \
+  --account-name podiumd<env>st \
+  --account-key  "${SA_KEY}" \
+  --container-name mi-exports \
+  --prefix "<env>/$(date -u +%y%m%d)/openzaak/" -o table
+```
+
+A successful CSV run logs e.g.:
+
+```
+[ts] starting MI export: component=openzaak schemas=public format=csv
+[ts] dumping public.zaken_zaak -> zaken_zaak.csv
+... (one line per table)
+[ts] packaging 127 CSV(s) into openzaak.tar.gz
+[ts] uploading <env>/260507/openzaak/095048-openzaak.tar.gz (482658 bytes)
+[ts] done: 127 table(s) packaged in <env>/260507/openzaak/095048-openzaak.tar.gz
+```
+
+A successful pgdump run logs:
+
+```
+[ts] starting MI export: component=openzaak schemas=public format=pgdump
+[ts] running pg_dump -Fc on openzaak (schemas: public)
+[ts] uploading <env>/260507/openzaak/095048-openzaak.pgdump (533748 bytes)
+[ts] done: pg_dump uploaded to <env>/260507/openzaak/095048-openzaak.pgdump
+```
+
+## Production / external hosting
+
+The Terraform in `ICATT-Menselijk-Digitaal/podiumd-infra` is **only for Dimpact's test/dev environments** (jim00, jos00, jimme00, etc.). Production environments hosted by external providers (e.g. SSC Twente — `dev.azure.com/ssctwente/ExternalsPodiumD`) need to replicate the same shape in their own Terraform module.
+
+### What the hosting provider must add
+
+Three resources, in their existing per-env Terraform that already provisions the storage account and Key Vault:
+
+```hcl
+# 1. Container on the existing standard SA
+resource "azurerm_storage_container" "mi_exports" {
+  name                  = "mi-exports"
+  storage_account_name  = azurerm_storage_account.podiumd_env.name
+  container_access_type = "private"
+}
+
+# 2. SA primary key in KV (read by the deploy pipeline)
+resource "azurerm_key_vault_secret" "mi_export_storage" {
+  name         = "mi-export-storage-${var.env_name}"
+  value        = azurerm_storage_account.podiumd_env.primary_access_key
+  key_vault_id = azurerm_key_vault.base.id
+
+  # Optional: rotate when SA key rotates
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# 3. (Optional but recommended) Lifecycle policy on the container
+#    Move blobs to Cool tier after 30d; delete after the gemeente's retention period.
+resource "azurerm_storage_management_policy" "mi_exports_lifecycle" {
+  storage_account_id = azurerm_storage_account.podiumd_env.id
+
+  rule {
+    name    = "mi-exports-tiering"
+    enabled = true
+    filters {
+      blob_types   = ["blockBlob"]
+      prefix_match = ["mi-exports/"]
+    }
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_modification_greater_than    = 30
+        tier_to_archive_after_days_since_modification_greater_than = 365
+        # delete_after_days_since_modification_greater_than = <set per gemeente policy>
+      }
+    }
+  }
+}
+```
+
+After the next deploy, materialise the cluster-side Secret:
+
+```bash
+SA_KEY=$(az keyvault secret show --vault-name <base-kv-name> \
+           --name mi-export-storage-<env> --query value -o tsv)
+
+kubectl -n podiumd create secret generic mi-export-storage \
+  --from-literal=AZURE_STORAGE_ACCOUNT=podiumd<env>st \
+  --from-literal=AZURE_STORAGE_KEY="${SA_KEY}" \
+  --from-literal=AZURE_STORAGE_CONTAINER=mi-exports
+```
+
+This step is one-shot per env, ideally automated as part of the deploy pipeline (the test/dev side has `scripts/sync-mi-export-secret.sh` for the same purpose; production providers can fold the same logic into their own pipeline).
+
+### What the hosting provider does *not* need
+
+- **No Workload Identity / federated credentials.** SA-key auth was chosen deliberately (see decision below).
+- **No SFTP / file share.** Blob is the only export sink.
+- **No new identity / RBAC** beyond access to the existing per-env SA's key.
+
+## Why SA keys, not workload identity
+
+Decision recorded during the iter1 design phase:
+
+- The export workload is a single-purpose batch job that needs only "write to one container in one SA". Wiring up federated credentials, role assignments, and identity bindings adds operational surface for no functional gain.
+- The SA primary key already lives in the base Key Vault; rotation of the key automatically refreshes the cached K8s Secret on the next deploy / sync run.
+- Workload Identity may be revisited if/when a future iteration needs cross-tenant access or fine-grained per-component credentials.
+
+## Operations
+
+### Reading the blobs
+
+For consumers with the SA key (or a SAS token issued from it):
+
+```bash
+# List all of today's exports for an env
+az storage blob list --account-name podiumd<env>st \
+  --account-key "${SA_KEY}" \
+  --container-name mi-exports \
+  --prefix "<env>/$(date -u +%y%m%d)/" -o table
+
+# Download a single component's tarball
+az storage blob download --account-name podiumd<env>st \
+  --account-key "${SA_KEY}" \
+  --container-name mi-exports \
+  --name "<env>/260507/openzaak/095048-openzaak.tar.gz" \
+  --file ./openzaak.tar.gz
+
+# Inspect the CSVs without extracting
+tar -tzf ./openzaak.tar.gz | head
+
+# For a pgdump file: list its TOC
+pg_restore --list ./openzaak.pgdump | head
+```
+
+> **Version note:** `pg_dump`/`pg_restore` in the chart's image (Azure Linux base + tdnf-installed `postgresql`) is currently PG16. A pgdump file written by PG16 cannot be read by older `pg_restore` clients — match the consumer's client version to PG16+ when restoring.
+
+### Retention
+
+The chart **does not** enforce retention on the blobs themselves; that's the SA's lifecycle-management policy. See the Terraform snippet above for a 30d-Cool / 365d-Archive default. Choose a `delete_after_days_…` value consistent with the gemeente's data-retention policy (typically 5 years for case-related data).
+
+### Run-success monitoring
+
+Iter1 ships **without** alerting. The CronJob's standard Job/Pod failure events surface in `kubectl get events -n podiumd`. A future iteration (IN-1993) wires up Prometheus alerting on missed schedules / failed runs.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `helm template` fails with `mi.format must be one of: csv, pgdump (got "X")` | Typo in `values-<env>.yml` | Set `mi.format` to `csv` or `pgdump` (or remove to use default `csv`). |
+| Job pod fails with `ERROR: AZURE_STORAGE_KEY: must be set` | `Secret/mi-export-storage` not present in podiumd ns | Run `scripts/sync-mi-export-secret.sh <env>` (test/dev) or apply the Secret manually (see [§ Production / external hosting](#production--external-hosting)). |
+| Job pod fails with `password authentication failed for user "<component>"` | The component's K8s Secret has a stale password (env was rebuilt but Secret wasn't refreshed) | Re-run the deploy pipeline's "Create PostgreSQL Databases and Users" step; or `kubectl delete secret/<component> -n podiumd` and let the chart recreate it. |
+| `csv` run logs `no tables found in schemas (...)` then exits 1 | Component's DB exists but has no tables (chart was deployed but the component's migration never ran) | Investigate the component's startup; the export script intentionally fails rather than upload an empty tarball. |
+| pgdump file rejected by `pg_restore` with `unsupported version (1.15)` | Consumer's PG client is older than PG16 | Use a PG16+ client to restore. |
+| All Jobs fire on the same minute on a large cluster and overload the SA | Default schedule is weekly Sunday 02:00 across all components | Stagger via per-target `schedule` overrides (chart values), or ask Azure for higher SA throughput tier. |
+
+## Changelog
+
+- **Iter1 (chart 4.6.x onwards)** — initial dump-to-blob, `csv`/`pgdump` env-wide knob, structured blob layout, gated per-component CronJobs.
+- **Iter2** *(not started)* — Keycloak-fronted web portal so consumers can browse/download without an SAS link.
+- **Iter3** ([IN-1993](https://dimpact.atlassian.net/browse/IN-1993)) — baked image (drop runtime `tdnf install`); SA lifecycle policy automation; Prometheus alerts on missed/failed runs; `ephemeral-storage` limits to bound /tmp use; per-table allow/deny lists.

--- a/docs/podiumd/mi-exports.md
+++ b/docs/podiumd/mi-exports.md
@@ -4,6 +4,8 @@ Weekly Management Information (MI) data exports of every Postgres-backed compone
 
 > Jira: [IN-1650](https://dimpact.atlassian.net/browse/IN-1650) (epic) / [IN-1691](https://dimpact.atlassian.net/browse/IN-1691) (iteration 1).
 
+> **⚠️ Opt-in feature — disabled by default.** Set `mi.enabled: true` in your env values file to turn it on. Doing so **only** has effect when the cloud-side prerequisites are already in place (Azure Blob Storage container + `Secret/mi-export-storage` in the `podiumd` namespace). Without those, the CronJob pods fail on first run. See [§ Activation in an environment](#activation-in-an-environment) for the full checklist.
+
 ## Audience
 
 Two readers:


### PR DESCRIPTION
> **🔄 Rebased onto `feature/podiumd-4.7` on 2026-05-10.** Previous base was `feature/info-podiumd-4.7`; the only merge conflict was an additive one in `charts/podiumd/values.yaml` (apisix and mi blocks both appended at end of file — both kept). Rebased history below; `helm template` with `apisix.enabled=true mi.enabled=true` renders cleanly, both new sources appear in the output, and `helm lint` failures are limited to pre-existing schema-validation against placeholder values (same set as before the rebase).

## Summary

Implements iter1 of IN-1650 / IN-1691 — weekly database exports for management-information consumers. One CronJob per Postgres-backed component the chart deploys, dumping into a blob container keyed per gemeente.

- **Default output:** per-table \\COPY → tar.gz of CSVs (one CSV per table inside the tarball).
- **Alternative output (env-wide knob):** `mi.format: pgdump` → single `pg_dump -Fc` per component (custom format, zlib-compressed, restorable via `pg_restore`).
- **Blob layout:** `<gemeente>/<YYMMDD>/<component>/<HHMMSS>-<component>.tar.gz` (csv) or `…-<component>.pgdump` (pgdump).
- Schema scoping via `mi.targets[].schemas` honoured by both formats; defaults to `["public"]`. zac uses `["flowable"]` out of the box.
- `<component>.enabled` gates each CronJob — disabling a component removes its export.

Also includes a Redis HA pre-delete hook (separate, related ops fix): drain the RedisReplication CR before the operator is torn down to avoid stuck-Terminating namespaces on `helm uninstall` (root-caused on dev rebuilds, full write-up in commit message).

## Validation

End-to-end on `jim00` on 2026-05-06: 462 blobs / 17.7 MiB across the 7 chart-enabled Postgres components for that env. Both `csv` and `pgdump` paths render and shellcheck clean; template-time validation rejects any `mi.format` other than the two supported values.

Post-rebase verification (2026-05-10):
- `helm template charts/podiumd/ --set apisix.enabled=true --set apisix.adminUi.hostname=... --set mi.enabled=true --set mi.gemeente=...` → both `# Source: podiumd/templates/mi-export-cronjobs.yaml` and `# Source: podiumd/templates/mi-export-scripts.yaml` render alongside the APISIX templates.
- `helm lint` failures are limited to pre-existing schema-validation against placeholder values (notifynl-omc-nodep + kiss require real values) — same set as before the rebase.

## Commits

```
94aa58f docs(mi-exports): point to ExternalsPodiumD ADO branch instead of inlining Terraform
2db84f5 docs(mi-exports): operator + external-hosting documentation
10d9e94 feat(mi-exports): add mi.format option for full pg_dump output
73291c0 fix(redis-operator): pre-delete hook to drain the RedisReplication CR
f0512e9 feat(mi-exports): one tar.gz per component per run instead of per-table CSVs
c7bf251 refactor(mi-exports): structured blob path layout (env/YYMMDD/component/file)
6abdf42 feat(mi-exports): weekly DB CSV exports to blob storage (IN-1650/IN-1691)
```

## Pairs with

Infra-side PR in `ICATT-Menselijk-Digitaal/podiumd-infra` provisions the `mi-exports` blob container on the existing per-env standard SA and stores the SA key in Key Vault. CronJobs in this PR consume that via the `mi-export-storage` K8s Secret (envFrom).

## Out of scope (iter2 / iter3 backlog — IN-1993)

- Keycloak-fronted web portal for consumers (iter2).
- Baked image (drop runtime tdnf install + re-enable runAsNonRoot).
- Lifecycle policy on the SA, run-success monitoring, per-table allow/deny lists.

## Test plan

- [ ] On a dev env, set `mi.enabled=true` and `mi.gemeente=<env>` in values; verify a CronJob renders for every enabled Postgres component.
- [ ] Manually trigger one CronJob (`kubectl create job --from=cronjob/mi-export-<component> mi-export-<component>-manual`) and verify the resulting `<component>.tar.gz` lands at the expected blob path.