### PR TITLE
Feature/podiumd 4.6.7

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.6.6
-appVersion: "4.6.6"
+version: 4.6.7
+appVersion: "4.6.7"
 dependencies:
   - name: keycloak-operator
     version: 1.11.2

--- a/charts/podiumd/docs/upgrade-from-4.6.6-to-4.6.7.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.6-to-4.6.7.md
@@ -1,4 +1,4 @@
-# Upgrade guide: PodiumD 4.6.5 → 4.6.6
+# Upgrade guide: PodiumD 4.6.6 → 4.6.7
 
 ## Changes
 

--- a/charts/podiumd/docs/upgrade-from-4.6.6-to-4.6.7.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.6-to-4.6.7.md
@@ -1,0 +1,12 @@
+# Upgrade guide: PodiumD 4.6.5 → 4.6.6
+
+## Changes
+
+### Patch version for Openinwoner
+
+Version of openinwoner goes from _2.x.x to 2.x.y_
+
+#### Action required
+
+
+No action required. 

--- a/charts/podiumd/docs/upgrade-from-4.6.6-to-4.6.7.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.6-to-4.6.7.md
@@ -4,7 +4,7 @@
 
 ### Patch version for Openinwoner
 
-Version of openinwoner goes from _2.x.x to 2.x.y_
+Version of openinwoner goes from 2.1.1 to 2.1.2-rc1
 
 #### Action required
 

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1832,7 +1832,7 @@ openinwoner:
   persistentVolume:
     volumeAttributeShareName: openinwoner
   image:
-    tag: "2.1.1"
+    tag: "2.1.2-rc1"
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
Based on main

## patch OIP

Er komt een Patch van OIP, deze moet worden opgenomen in deze release, 4.6.7
Container image geüpdated van 2.1.1 naar **2.1.2-rc1** 

Deze patch is nodig om [[DRT-557] No Go productie-uitrol 4.6 – Gemeente Groningen - Jira](https://dimpact.atlassian.net/browse/DRT-557) op te lossen
