### PR TITLE
Feature/podiumd 4.6.8

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.6.7
-appVersion: "4.6.7"
+version: 4.6.8
+appVersion: "4.6.8"
 dependencies:
   - name: keycloak-operator
     version: 1.11.2

--- a/charts/podiumd/docs/images/images-4.6.8.yaml
+++ b/charts/podiumd/docs/images/images-4.6.8.yaml
@@ -1,0 +1,15 @@
+# Images new or changed in podiumd 4.6.8 vs 4.6.7.
+#
+# Single change: open-inwoner 2.1.2-rc1 -> 2.1.2 (release candidate
+# promoted to stable upstream tag). No other image, tag, or digest
+# changes between 4.6.7 and 4.6.8.
+#
+# Mirror name is `openinwoner` (no hyphen), not `open-inwoner`; see
+# docs/images/acr-mirror-naming.md on the 4.7 line for the upstream->ACR
+# mapping.
+
+# Open Inwoner Platform (OIP)
+- name: openinwoner
+  url: docker.io/maykinmedia/open-inwoner
+  version: "2.1.2"
+  digest: "sha256:d4158f4f6f0890c7c94099332de034da0f6cf1fed298a79447934aa8c9d3236d"

--- a/charts/podiumd/docs/upgrade-from-4.6.7-to-4.6.8.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.7-to-4.6.8.md
@@ -4,7 +4,7 @@
 
 ### Patch version for Openinwoner
 
-Include proper image release of Open Inwoer: 2.1.2
+Replace OIP 2.1.2-rc1 with proper image release of Open Inwoer: 2.1.2
 
 #### Action required
 

--- a/charts/podiumd/docs/upgrade-from-4.6.7-to-4.6.8.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.7-to-4.6.8.md
@@ -1,0 +1,12 @@
+# Upgrade guide: PodiumD 4.6.7 → 4.6.8
+
+## Changes
+
+### Patch version for Openinwoner
+
+Include proper image release of Open Inwoer: 2.1.2
+
+#### Action required
+
+
+No action required. 

--- a/charts/podiumd/docs/upgrade-from-4.6.7-to-4.6.8.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.7-to-4.6.8.md
@@ -4,7 +4,7 @@
 
 ### Patch version for Openinwoner
 
-Replace OIP 2.1.2-rc1 with proper image release of Open Inwoer: 2.1.2
+Replace OIP 2.1.2-rc1 with proper image release of Open Inwoner: 2.1.2
 
 #### Action required
 

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1832,7 +1832,7 @@ openinwoner:
   persistentVolume:
     volumeAttributeShareName: openinwoner
   image:
-    tag: "2.1.2-rc1"
+    tag: "2.1.2"
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
Based on main

## proper patch OIP
In  4.6.7 is container image van OpenInwoner geüpdated van 2.1.1 naar 2.1.2-rc1
In deze release is de final 2.1.2 opgenomen.

## don't merge to main
## create next minor PR from this branch when done
## rename to release/xxx to trigger release when done