### PR TITLE
feature: PodiumD 4.7.1

### DIFF
--- a/.claude/commands/fetch-image-digest.md
+++ b/.claude/commands/fetch-image-digest.md
@@ -1,0 +1,50 @@
+Fetch the OCI manifest digest (`sha256:...`) for a container image. Used by `/images-manifest` and ad-hoc when verifying a new image entry.
+
+Usage: `/fetch-image-digest <registry>/<repository>:<tag>`
+
+Examples:
+- `/fetch-image-digest docker.io/openzaak/open-zaak:1.27.1`
+- `/fetch-image-digest quay.io/keycloak/keycloak:26.6.1`
+- `/fetch-image-digest ghcr.io/infonl/zaakafhandelcomponent:4.7.1`
+
+Behavior:
+
+1. Parse `$ARGUMENTS` into registry, repository, tag. Reject if any piece is missing.
+2. Resolve auth:
+   - **Docker Hub** (`docker.io`, also accept bare `library/<name>`): first GET `https://auth.docker.io/token?service=registry.docker.io&scope=repository:<repo>:pull` to obtain a bearer token. Use the returned `token` in the `Authorization: Bearer` header for step 3.
+   - **GHCR** (`ghcr.io`): GET `https://ghcr.io/token?scope=repository:<repo>:pull` for an anonymous token. Same `Authorization: Bearer` flow.
+   - **Quay** (`quay.io`), **gcr.io**, **registry.k8s.io**: no token required for public manifests.
+3. Request the manifest:
+   ```
+   GET https://<registry-host>/v2/<repository>/manifests/<tag>
+   Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+   ```
+   Note: for `docker.io`, the host in the URL is `registry-1.docker.io`. Single-component repos like `nginx` must be prefixed with `library/` (so `library/nginx`).
+4. Read the `Docker-Content-Digest` response header — that is the canonical multi-arch index digest. Print it.
+5. If the header is missing (rare — usually a redirect), follow the `Location` header once and retry.
+
+Reference Python snippet (use this verbatim with `python -c`):
+
+```python
+import sys, urllib.request, json
+spec = sys.argv[1]               # e.g. docker.io/openzaak/open-zaak:1.27.1
+host_repo, tag = spec.rsplit(':', 1)
+host, repo = host_repo.split('/', 1)
+api_host = 'registry-1.docker.io' if host == 'docker.io' else host
+if host == 'docker.io' and '/' not in repo:
+    repo = 'library/' + repo
+auth = {}
+if host == 'docker.io':
+    t = urllib.request.urlopen(f'https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull').read()
+    auth['Authorization'] = 'Bearer ' + json.loads(t)['token']
+elif host == 'ghcr.io':
+    t = urllib.request.urlopen(f'https://ghcr.io/token?scope=repository:{repo}:pull').read()
+    auth['Authorization'] = 'Bearer ' + json.loads(t)['token']
+req = urllib.request.Request(
+    f'https://{api_host}/v2/{repo}/manifests/{tag}',
+    headers={**auth, 'Accept': 'application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'})
+with urllib.request.urlopen(req) as r:
+    print(r.headers['Docker-Content-Digest'])
+```
+
+Output exactly one line: the `sha256:...` digest. If the lookup fails, report the HTTP status and which step failed (token vs manifest).

--- a/.claude/commands/helm-bomcheck.md
+++ b/.claude/commands/helm-bomcheck.md
@@ -1,0 +1,16 @@
+Check `charts/podiumd/values.yaml` for UTF-8 BOM (bytes `0xEF 0xBB 0xBF`) that breaks YAML tooling. Strip if present.
+
+```powershell
+$path = "charts/podiumd/values.yaml"
+$bytes = [System.IO.File]::ReadAllBytes($path)
+if ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+    [System.IO.File]::WriteAllBytes($path, $bytes[3..($bytes.Length-1)])
+    Write-Host "BOM removed from $path"
+} else {
+    Write-Host "No BOM - OK"
+}
+```
+
+If `$ARGUMENTS` is a path, check that file instead of the default.
+
+Report result. If BOM was stripped, remind user the file was modified and should be re-staged.

--- a/.claude/commands/helm-deps.md
+++ b/.claude/commands/helm-deps.md
@@ -1,0 +1,11 @@
+Update and rebuild the podiumd Helm chart dependencies.
+
+Run these commands from the repo root:
+
+```bash
+cd charts/podiumd && helm dependency update && helm dependency build
+```
+
+After completion:
+- Report which dependencies were updated (compare Chart.lock before/after if needed).
+- Remind the user to commit `Chart.lock` and the updated `.tgz` files in `charts/podiumd/charts/`.

--- a/.claude/commands/helm-dupecheck.md
+++ b/.claude/commands/helm-dupecheck.md
@@ -1,0 +1,81 @@
+Scan charts/podiumd/values.yaml for duplicate YAML keys that silently overwrite earlier values.
+
+Run the appropriate variant based on whether changes are staged or not.
+
+**Working tree variant** (before `git add`):
+
+```powershell
+$script = @'
+import re
+lines = open(r'charts/podiumd/values.yaml', encoding='utf-8').readlines()
+stack = []
+scope_keys = {}
+duplicates = []
+for i, line in enumerate(lines, 1):
+    stripped = line.lstrip()
+    if stripped.startswith('#') or stripped.startswith('-'):
+        continue
+    m = re.match(r'^(\s*)([a-zA-Z0-9_\-][^:#\n]*?)\s*:', line)
+    if not m:
+        continue
+    indent = len(m.group(1))
+    key = m.group(2).strip()
+    while stack and stack[-1][0] >= indent:
+        stack.pop()
+    scope_id = tuple(k for _,k in stack)
+    if scope_id not in scope_keys:
+        scope_keys[scope_id] = {}
+    if key in scope_keys[scope_id]:
+        parent = ' > '.join(scope_id) if scope_id else '(root)'
+        duplicates.append(f'Line {i}: duplicate "{key}" under [{parent}] (first line {scope_keys[scope_id][key]})')
+    else:
+        scope_keys[scope_id][key] = i
+    stack.append((indent, key))
+if duplicates:
+    print(f'FOUND {len(duplicates)} duplicate(s):')
+    for d in duplicates: print(' ', d)
+else:
+    print('No duplicate keys found')
+'@
+$script | python
+```
+
+**Staged variant** (after `git add`, before `git commit`):
+
+```powershell
+$script = @'
+import re, sys
+lines = sys.stdin.read().splitlines(keepends=True)
+stack = []
+scope_keys = {}
+duplicates = []
+for i, line in enumerate(lines, 1):
+    stripped = line.lstrip()
+    if stripped.startswith('#') or stripped.startswith('-'):
+        continue
+    m = re.match(r'^(\s*)([a-zA-Z0-9_\-][^:#\n]*?)\s*:', line)
+    if not m:
+        continue
+    indent = len(m.group(1))
+    key = m.group(2).strip()
+    while stack and stack[-1][0] >= indent:
+        stack.pop()
+    scope_id = tuple(k for _,k in stack)
+    if scope_id not in scope_keys:
+        scope_keys[scope_id] = {}
+    if key in scope_keys[scope_id]:
+        parent = ' > '.join(scope_id) if scope_id else '(root)'
+        duplicates.append(f'Line {i}: duplicate "{key}" under [{parent}] (first line {scope_keys[scope_id][key]})')
+    else:
+        scope_keys[scope_id][key] = i
+    stack.append((indent, key))
+if duplicates:
+    print(f'FOUND {len(duplicates)} duplicate(s):')
+    for d in duplicates: print(' ', d)
+else:
+    print('No duplicate keys found')
+'@
+git show :charts/podiumd/values.yaml | python -c $script
+```
+
+After running, report any duplicates found. Hits inside YAML sequences (list items with shared key names like `value:` or `mountPath:`) are false positives — ignore them.

--- a/.claude/commands/helm-fetch-updates.md
+++ b/.claude/commands/helm-fetch-updates.md
@@ -1,0 +1,21 @@
+Check whether the local repo is fresh enough to start work. Refresh if stale. Rule lives in `.github/copilot-instructions.md` under "Check repo updates before work".
+
+Steps:
+
+1. Read the timestamp of `.git/FETCH_HEAD` (or `.git/HEAD` if `FETCH_HEAD` doesn't exist). Compare to now.
+2. If older than 24 hours, run:
+   ```bash
+   git fetch --all --prune
+   ```
+3. Show new upstream commits on the current branch and on `origin/main`:
+   ```bash
+   git log --oneline HEAD..@{u} 2>$null
+   git log --oneline HEAD..origin/main
+   ```
+4. If `$ARGUMENTS` is `--pull` AND the current branch has an upstream AND there are no local uncommitted changes (check `git status --porcelain`), run `git pull --ff-only`. Otherwise, only report; never auto-pull on a dirty working tree.
+5. If the user also has the external ZAC repo (`C:\Users\johnb\IdeaProjects\dimpact-zaakafhandelcomponent`) and `$ARGUMENTS` contains `--zac`, repeat the freshness check there (read-only — no auto-pull).
+
+Final report:
+- Last fetch age (e.g. "3h 12m" or "2 days").
+- Commits behind upstream / behind main.
+- Whether a fetch and/or pull happened, or just a report.

--- a/.claude/commands/helm-lint.md
+++ b/.claude/commands/helm-lint.md
@@ -1,0 +1,13 @@
+Lint the podiumd Helm chart.
+
+```bash
+helm lint charts/podiumd
+```
+
+If $ARGUMENTS contains a values file path, also lint with that file:
+
+```bash
+helm lint charts/podiumd -f $ARGUMENTS
+```
+
+Report all warnings and errors. For errors, diagnose the root cause and suggest fixes.

--- a/.claude/commands/helm-precommit.md
+++ b/.claude/commands/helm-precommit.md
@@ -1,0 +1,27 @@
+Run the full pre-commit hygiene sweep for `charts/podiumd/values.yaml` and templates before staging a commit.
+
+Sequence (stop on first failure, report which step failed):
+
+1. **BOM check** — invoke `/helm-bomcheck`. Fail if a BOM was present (file just got rewritten; user must re-stage).
+2. **Duplicate key scan** — invoke `/helm-dupecheck`. Fail if any non-list duplicate is reported.
+3. **Lint with CI values** —
+   ```bash
+   helm lint charts/podiumd -f charts/podiumd/ci/lint-values.yaml
+   ```
+   Fail on errors. Warnings are reported but do not fail.
+4. **Full render** — invoke `/helm-render-all`. Fail on render errors.
+
+If `$ARGUMENTS` names one or more specific templates (e.g. `keycloak-cr.yaml`), also invoke `/helm-render <template>` for each as a final focused check (per the "always verify values.yaml with helm render" rule in memory).
+
+Final report format:
+
+```
+PRECOMMIT SUMMARY
+  BOM check      : PASS|FAIL (<detail>)
+  Dupe check     : PASS|FAIL (<count>)
+  Lint           : PASS|FAIL (<error count>, <warning count>)
+  Full render    : PASS|FAIL
+  Targeted render: <template> PASS|FAIL  (only if $ARGUMENTS given)
+```
+
+If everything passes, tell the user it is safe to `git add` and commit. Never commit automatically — wait for explicit approval.

--- a/.claude/commands/helm-render-all.md
+++ b/.claude/commands/helm-render-all.md
@@ -1,0 +1,23 @@
+Render the full podiumd chart with CI lint values for end-to-end template validation.
+
+Usage: `/helm-render-all` (no args) or `/helm-render-all <extra-values.yaml>` to overlay an additional values file.
+
+Default command:
+
+```bash
+helm template podiumd charts/podiumd \
+  -f charts/podiumd/ci/lint-values.yaml \
+  --skip-schema-validation
+```
+
+If `$ARGUMENTS` is a path to a values file, append `-f $ARGUMENTS` before the `--skip-schema-validation` flag.
+
+Notes:
+- `ci/lint-values.yaml` is required — default `values.yaml` leaves security fields blank and fails validation.
+- `--skip-schema-validation` is required — KISS sub-chart JSON schema demands fields the CI values don't supply.
+- Pipe output through `Select-String -Pattern "Error|error"` first if rendering succeeds visually but you want a quick sanity check.
+
+After running, report:
+- whether the render succeeded,
+- any sub-chart errors (group by sub-chart),
+- and which templates produced the most output (helps spot accidental explosions from new loops).

--- a/.claude/commands/helm-render.md
+++ b/.claude/commands/helm-render.md
@@ -1,0 +1,31 @@
+Render a single podiumd template without errors from unrelated sub-charts.
+
+Usage: /helm-render <template.yaml> [extra --set flags]
+
+Steps:
+1. Run the following command (substitute the template name from $ARGUMENTS):
+
+```bash
+helm template podiumd charts/podiumd \
+  -s templates/$ARGUMENTS \
+  --set kiss.enabled=false \
+  --set "zgw-office-addin.enabled=false" \
+  --set zac.enabled=false \
+  --set opennotificaties.enabled=false \
+  --set openklant.enabled=false \
+  --set openformulieren.enabled=false \
+  --set openinwoner.enabled=false \
+  --set kisselastic.enabled=false \
+  --set ita.enabled=false \
+  --set pabc.enabled=false \
+  --set clamav.enabled=false \
+  --set brppersonenmock.enabled=false \
+  --set infinispan.enabled=false \
+  --set "global.security.allowInsecureImages=true" \
+  --skip-schema-validation
+```
+
+2. Show the rendered YAML output.
+3. If there are errors, diagnose them and suggest fixes.
+
+Note: if the template references sub-chart named templates (e.g. create-required-catalogi.yaml, create-required-objecttypen.yaml), do NOT disable openzaak/objecten/objecttypen.

--- a/.claude/commands/helm-repos.md
+++ b/.claude/commands/helm-repos.md
@@ -1,0 +1,16 @@
+Add all required Helm repositories for the podiumd chart.
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add maykinmedia https://maykinmedia.github.io/charts/
+helm repo add wiremind https://wiremind.github.io/wiremind-helm-charts
+helm repo add dimpact https://Dimpact-Samenwerking.github.io/helm-charts/
+helm repo add kiss-elastic https://raw.githubusercontent.com/Klantinteractie-Servicesysteem/.github/main/docs/scripts/elastic
+helm repo add zac https://infonl.github.io/dimpact-zaakafhandelcomponent/
+helm repo add zgw-office-addin https://infonl.github.io/zgw-office-addin
+helm repo add adfinis https://charts.adfinis.com
+helm repo add opstree https://ot-container-kit.github.io/helm-charts/
+helm repo update
+```
+
+Report which repos were added and which already existed.

--- a/.claude/commands/helm-tgz-inspect.md
+++ b/.claude/commands/helm-tgz-inspect.md
@@ -1,0 +1,25 @@
+Inspect a vendored sub-chart `.tgz` package in `charts/podiumd/charts/` without extracting it.
+
+Usage: `/helm-tgz-inspect <chart-name>[:<inner-path>]`
+
+Examples:
+- `/helm-tgz-inspect openzaak` — list contents of the chart tarball
+- `/helm-tgz-inspect openzaak:openzaak/templates/deployment.yaml` — read one file from the tarball to stdout
+
+Why this skill exists: Helm prefers an extracted chart directory over a `.tgz` of the same name. If you ever `tar -xzf` a vendored package or check out an extracted version, `helm template`/`lint`/`upgrade` silently uses the extracted copy instead of the pinned package — which has caused broken deployments. **Always inspect without extracting.**
+
+Behavior:
+
+1. Resolve the tarball: find the newest matching file under `charts/podiumd/charts/` whose name starts with `<chart-name>-`.
+2. If `$ARGUMENTS` has no colon, run:
+   ```bash
+   tar -tzf charts/podiumd/charts/<resolved>.tgz
+   ```
+3. If `$ARGUMENTS` is `<chart-name>:<inner-path>`, run:
+   ```bash
+   tar -xzOf charts/podiumd/charts/<resolved>.tgz <inner-path>
+   ```
+   (`-O` writes to stdout instead of disk.)
+4. Never run `tar -xzf` (extracting), never `cd` into an extracted directory.
+
+If you find that `charts/podiumd/charts/<chart-name>/` exists as a directory next to the `.tgz`, warn the user — it must be deleted (along with verifying the `.tgz` is still present and pinned) before any Helm operation.

--- a/.claude/commands/images-manifest.md
+++ b/.claude/commands/images-manifest.md
@@ -1,0 +1,36 @@
+Create an images manifest for a podiumd release.
+
+Usage: `/images-manifest <version>` (e.g. `/images-manifest 4.7.1`)
+
+Output path:
+```
+charts/podiumd/docs/images/images-$ARGUMENTS.yaml
+```
+
+Rules:
+- Include **only** images new or changed compared to the previous release (tag bumps, new sidecars/exporters, newly digest-pinned entries even if the tag is unchanged — call those out in a comment like `# newly digest-pinned in <version>; tag unchanged`).
+- Every listed image must have a corresponding `{registry, repository, tag}` entry in `values.yaml` — never invent versions.
+- Each entry requires a `digest` field (`sha256:...`) fetched from the source registry via `/fetch-image-digest`.
+- Format: flat YAML list, no pipeline wrapper, no indentation on list items.
+- Use the **component name from the chart** (e.g. `openinwoner`, not `open-inwoner`).
+- Group entries with short Dutch comments at the top of each section. Real-world groupings seen in `images-4.7.0.yaml`:
+  - `# <App name>` (one comment per logical app, e.g. `# Open Zaak`, `# ZAC`, `# Keycloak (operator + server)`)
+  - `# <App> - <sidecar>` for sidecars (e.g. `# ZAC - Open Policy Agent`)
+  - `# APISIX - oauth2-proxy (Keycloak SSO sidecar for admin UI)` — short Dutch context is fine in parens.
+- File header is a single comment line: `# Images die nieuw of gewijzigd zijn in podiumd <version> t.o.v. <prev>.`
+- Mirror the field order from `ExternalsPodiumD/pipelines/images.yml`: `name`, `url`, `version`, `digest`.
+
+Steps:
+
+1. Find the previous release manifest under `charts/podiumd/docs/images/` (highest semver less than `$ARGUMENTS`). Use it as both a template for grouping/style **and** the baseline for what to exclude.
+2. Detect changes:
+   ```powershell
+   git diff <prev-tag>...HEAD -- charts/podiumd/values.yaml | Select-String "^\+.*tag:"
+   git diff <prev-tag>...HEAD -- charts/podiumd/Chart.yaml
+   ```
+   If the previous git tag doesn't exist, diff against `main`.
+3. For every changed image, invoke `/fetch-image-digest <registry>/<repo>:<tag>` to obtain the digest. Never hand-write digests.
+4. Reuse the previous manifest's comment grouping where the same images still apply; add new groups only for new apps.
+5. Write the file. Reference style: `images-4.7.0.yaml`.
+6. Run `/helm-dupecheck` to verify `values.yaml` is clean before finalizing.
+7. After writing, print: file path, count of entries, and any image whose digest fetch failed (must be resolved before commit).

--- a/.claude/commands/upgrade-notes.md
+++ b/.claude/commands/upgrade-notes.md
@@ -1,0 +1,26 @@
+Scaffold the per-release upgrade guide for a podiumd version bump.
+
+Usage: `/upgrade-notes <prev>-to-<new>` (e.g. `/upgrade-notes 4.7.0-to-4.7.1`)
+
+Output path:
+```
+charts/podiumd/docs/upgrade-from-<prev>-to-<new>.md
+```
+
+Steps:
+
+1. Refuse if `$ARGUMENTS` is missing or does not match `<X.Y.Z>-to-<X.Y.Z>`.
+2. Read the most recent existing upgrade doc under `charts/podiumd/docs/upgrade-from-*.md` (sort by mtime) to mirror its tone and section order. Style reference: `upgrade-from-4.5.13-to-4.6.0.md`.
+3. Compute changes between the two refs (tag the previous release if it exists, otherwise diff `main...HEAD`):
+   ```powershell
+   git diff <prev-ref>...HEAD -- charts/podiumd/Chart.yaml charts/podiumd/values.yaml
+   ```
+4. Populate these sections (drop a section entirely if there's nothing to say — do NOT leave empty headers):
+   - **New images requiring ACR override** — key paths + `values.yaml` snippets for any new `{registry, repository, tag}` triples.
+   - **New optional components** — sub-charts newly enabled or newly available.
+   - **Removed or deprecated components** — anything turned off/removed.
+   - **Required manual steps** — DB migrations, secret rotations, cluster-side prep.
+   - **Component version bump table** — markdown table with columns `| Component | old | new |` derived from `Chart.yaml` diff.
+5. Cross-reference the matching `charts/podiumd/docs/images/images-<new>.yaml` if it exists; if not, remind the user to run `/images-manifest <new>`.
+6. Do not invent versions. Every component row must be backed by `Chart.yaml`; every image must be backed by `values.yaml`.
+7. After writing, print the file path and a one-line summary of which sections were filled.

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 /charts/**/charts/
 /charts/**/Chart.lock
 /http-client.private.env.json
-# Claude Code local settings
-.claude/
+# Claude Code local settings (track .claude/commands/ only)
+.claude/*
+!.claude/commands/
 
 # Local-only operator scripts (per-engineer Azure context, not chart artifacts)
 /charts/podiumd/scripts/cluster-status.sh

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: brppersonenmock.enabled
     alias: brppersonenmock
   - name: openzaak
-    version: 1.13.1
+    version: 1.14.1
     repository: "@maykinmedia"
     condition: openzaak.enabled
   - name: opennotificaties

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
   - name: internetaakafhandeling
     alias: ita
     repository: "oci://ghcr.io/interne-taak-afhandeling"
-    version: 3.0.0
+    version: 3.1.0
     condition: ita.enabled
   - name: kiss-chart
     alias: kiss

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.7.0
-appVersion: "4.7.0"
+version: 4.7.1
+appVersion: "4.7.1"
 dependencies:
   - name: keycloak-operator
     version: 1.11.4

--- a/charts/podiumd/docs/images/images-4.7.0.yaml
+++ b/charts/podiumd/docs/images/images-4.7.0.yaml
@@ -36,8 +36,8 @@
   version: "1.30.0"
   digest: "sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad"
 
-# alpine/k8s (redis-ha label-master job)
-- name: alpine-k8s
+# alpine/k8s (redis-ha label-master job) — ACR mirror repo path: k8s
+- name: k8s
   url: docker.io/alpine/k8s
   version: "1.34.7"
   digest: "sha256:4745677e51c0fb567aedf1453a7bd489e0a62dbbf2bda475d663f7eed041adb4"

--- a/charts/podiumd/docs/images/images-4.7.1.yaml
+++ b/charts/podiumd/docs/images/images-4.7.1.yaml
@@ -9,4 +9,3 @@
         url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.poller
         version: "3.1.0"
         digest: "sha256:67fa6cd37b9d38cd7317ee714a553b4bb2250d8998d2481e0f4cd2311e089383"
-

--- a/charts/podiumd/docs/images/images-4.7.1.yaml
+++ b/charts/podiumd/docs/images/images-4.7.1.yaml
@@ -1,0 +1,12 @@
+# Images die nieuw of gewijzigd zijn in podiumd 4.7.1 t.o.v. 4.7.0.
+
+# ITA / Internetaakafhandekling
+      - name: internetaakafhandeling.web
+        url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.web
+        digest: "sha256:40bcd34e672366fd71f4522775259c85580348a373a53a8ff3235bcb8aeeda06" 
+        version: "3.1.0"
+      - name: internetaakafhandeling.poller
+        url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.poller
+        version: "3.1.0"
+        digest: "sha256:67fa6cd37b9d38cd7317ee714a553b4bb2250d8998d2481e0f4cd2311e089383"
+

--- a/charts/podiumd/docs/images/images-4.7.1.yaml
+++ b/charts/podiumd/docs/images/images-4.7.1.yaml
@@ -1,11 +1,12 @@
 # Images die nieuw of gewijzigd zijn in podiumd 4.7.1 t.o.v. 4.7.0.
 
-# ITA / Internetaakafhandekling
-      - name: internetaakafhandeling.web
-        url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.web
-        digest: "sha256:40bcd34e672366fd71f4522775259c85580348a373a53a8ff3235bcb8aeeda06" 
-        version: "3.1.0"
-      - name: internetaakafhandeling.poller
-        url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.poller
-        version: "3.1.0"
-        digest: "sha256:67fa6cd37b9d38cd7317ee714a553b4bb2250d8998d2481e0f4cd2311e089383"
+# ITA / Internetaakafhandeling
+- name: internetaakafhandeling.web
+  url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.web
+  version: "3.1.0"
+  digest: "sha256:40bcd34e672366fd71f4522775259c85580348a373a53a8ff3235bcb8aeeda06"
+
+- name: internetaakafhandeling.poller
+  url: ghcr.io/interne-taak-afhandeling/internetaakafhandeling.poller
+  version: "3.1.0"
+  digest: "sha256:67fa6cd37b9d38cd7317ee714a553b4bb2250d8998d2481e0f4cd2311e089383"

--- a/charts/podiumd/docs/upgrade-from-4.7.0-to-4.7.1.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.0-to-4.7.1.md
@@ -1,0 +1,12 @@
+# Upgrade guide: PodiumD 4.7.0 → 4.7.1
+
+## Changes
+
+### Patch version for IA
+
+Version of ITA goes from 3.0.0 to 3.1.0
+
+#### Action required
+
+
+No action required. 

--- a/charts/podiumd/docs/upgrade-from-4.7.0-to-4.7.1.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.0-to-4.7.1.md
@@ -8,4 +8,75 @@ Version of ITA goes from 3.0.0 to 3.1.0
 
 #### Action required
 
-No action required. 
+No action required.
+
+### Open Zaak sub-chart 1.13.1 → 1.14.1
+
+The Open Zaak sub-chart is bumped from `1.13.1` to `1.14.1` (sub-chart
+default `appVersion` moves 1.26.0 → 1.28.1; PodiumD keeps the Open Zaak
+**application image pinned at 1.27.1**, so the running app version does
+not change in this release).
+
+Chart 1.14.1 introduces a configurable **Documenten API storage backend**.
+PodiumD does not set any of these keys, so the chart defaults apply and
+behaviour is unchanged after the upgrade (documents keep using the
+existing `filesystem` backend, Cloud Events stay disabled).
+
+#### New configuration options
+
+These are exposed under the `openzaak:` key in `values.yaml` and may be
+useful for production environments that want object storage instead of a
+filesystem PersistentVolume for Documenten API files:
+
+| Key | Default | Purpose |
+|---|---|---|
+| `openzaak.documentApiBackend` | `filesystem` | Storage backend for the Documenten API. One of: `filesystem`, `azure_blob_storage`, `s3_storage`. |
+| `openzaak.azureBlobStorage.accountName` | `""` | Azure Storage account name. |
+| `openzaak.azureBlobStorage.clientId` | `""` | Entra ID client id (workload identity / service principal). |
+| `openzaak.azureBlobStorage.clientSecret` | `""` | Entra ID client secret. |
+| `openzaak.azureBlobStorage.tenantId` | `""` | Entra ID tenant id. |
+| `openzaak.azureBlobStorage.container` | `openzaak` | Blob container name. |
+| `openzaak.azureBlobStorage.location` | `documenten` | Path/prefix within the container. |
+| `openzaak.azureBlobStorage.connectionTimeout` | `5` | Connection timeout (seconds). |
+| `openzaak.azureBlobStorage.apiStorageVersion` | `""` | Pin a specific Azure Storage API version (optional). |
+| `openzaak.azureBlobStorage.urlExpirationTime` | `60` | Signed-URL expiry (seconds). |
+| `openzaak.s3storage.accessKeyId` | `""` | S3 access key id. |
+| `openzaak.s3storage.secretAccessKey` | `""` | S3 secret access key. |
+| `openzaak.s3storage.storageBucketName` | `openzaak` | S3 bucket name. |
+| `openzaak.s3storage.maxMemorySize` | `0` | Max in-memory size before spooling to disk (bytes; `0` = default). |
+| `openzaak.s3storage.querystringExpire` | `60` | Signed-URL expiry (seconds). |
+| `openzaak.s3storage.fileOverwrite` | `false` | Allow overwriting an existing object with the same key. |
+| `openzaak.s3storage.location` | `documenten/` | Key prefix within the bucket. |
+| `openzaak.s3storage.regionName` | `""` | S3 region. |
+| `openzaak.s3storage.endpointUrl` | `""` | Custom S3 endpoint (for non-AWS / S3-compatible stores). |
+| `openzaak.s3storage.customDomain` | `""` | Custom domain used when generating object URLs. |
+| `openzaak.enableCloudEvents` | `false` | Emit CloudEvents for Documenten API changes. |
+| `openzaak.notificationsSource` | `openzaak` | `source` attribute on emitted CloudEvents. |
+
+#### Action required
+
+None to stay on the current behaviour — leave these keys unset and the
+`filesystem` backend continues to be used.
+
+> **WARNING — backend migration must be investigated and performed
+> first.** Switching `openzaak.documentApiBackend` away from
+> `filesystem` to `azure_blob_storage` or `s3_storage` does **not**
+> migrate existing documents. Files already written to the filesystem
+> PersistentVolume will become **inaccessible** to the Documenten API
+> the moment the backend is changed, and newly stored files go only to
+> the new backend. Before flipping the backend in production you MUST:
+>
+> 1. Investigate the current document volume (count, total size, PV
+>    contents) and the target object-store capacity/permissions.
+> 2. Plan and validate a data-migration path that copies all existing
+>    Documenten API files from the filesystem PV into the target
+>    Azure Blob / S3 location, preserving the keys/paths Open Zaak
+>    expects.
+> 3. Execute and verify the migration (read-back checks) in a
+>    non-production environment first.
+> 4. Only then change `openzaak.documentApiBackend` and roll out, with
+>    a tested rollback (keep the filesystem PV until the new backend is
+>    confirmed good).
+>
+> Do not change the backend as part of a routine 4.7.0 → 4.7.1 upgrade.
+> Treat it as a separate, planned migration project.

--- a/charts/podiumd/docs/upgrade-from-4.7.0-to-4.7.1.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.0-to-4.7.1.md
@@ -8,5 +8,4 @@ Version of ITA goes from 3.0.0 to 3.1.0
 
 #### Action required
 
-
 No action required. 

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2237,7 +2237,7 @@ openbeheer:
       rateUser: "15000/hour"
   nginx:
     image:
-      tag: "1.30.0"
+      tag: "1.30.0@sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad"
     resources:
       requests:
         cpu: 10m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3060,7 +3060,7 @@ ita:
   web:
     image:
       # repository: "ghcr.io/interne-taak-afhandeling/internetaakafhandeling.web"
-      tag: "3.0.0"
+      tag: "3.1.0"
       pullPolicy: IfNotPresent
 
     service:
@@ -3096,7 +3096,7 @@ ita:
 
     image:
       repository: "ghcr.io/interne-taak-afhandeling/internetaakafhandeling.poller"
-      tag: "3.0.0"
+      tag: "3.1.0"
       pullPolicy: IfNotPresent
 
     notification:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2237,7 +2237,7 @@ openbeheer:
       rateUser: "15000/hour"
   nginx:
     image:
-      tag: "1.30.0@sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad"
+      tag: "1.30.0"
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
## Summary

- Bump chart `version` and `appVersion` from `4.7.0` → `4.7.1`.

Patch release line opened on top of `4.7.0` (`d6e9db4`). Subsequent fixes for `4.7.1` should land on this branch.

* IN-2062 - ITA 3.1.0 opnemen in PodiumD 4.7
* IN-2066 - Update OpenZaak Helm naar 1.14.1

## Test plan

- [x] `helm lint charts/podiumd -f charts/podiumd/ci/lint-values.yaml`
- [x] `helm template podiumd charts/podiumd` renders cleanly
- [x] Verify any image/digest bumps land before promotion
- [x] Smoke deploy against a test environment