### PR TITLE
feat(podiumd): add zaakbrug subchart + onboarding docs (IN-1865)

### DIFF
--- a/charts/podiumd/docs/images/images-4.7.2.yaml
+++ b/charts/podiumd/docs/images/images-4.7.2.yaml
@@ -53,3 +53,9 @@
   url: docker.io/apache/apisix
   version: "3.16.0-ubuntu"
   digest: "sha256:5e47692cac00f2aca9d0b2b31cdf24445a7d975d6061626d269f47cc083a4b0e"
+
+# zaakbrug (Frank!Framework adapter, opt-in via zaakbrug.enabled=true; IN-1865)
+- name: zaakbrug
+  url: docker.io/wearefrank/zaakbrug
+  version: "1.26.13"
+  digest: "sha256:388c5d9d0646f7f38841728224711aeff9d0d6d80c50bc5f49959ddc7d89ff27"

--- a/charts/podiumd/docs/upgrade-from-4.7.1-to-4.7.2.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.1-to-4.7.2.md
@@ -42,6 +42,11 @@ component databases — `openzaak`, `openklant`, `ita`, etc.):
 - Owner role: `zaakbrug`
 - Default privileges on the role for `public` schema
 - `ssl: true` (TLS enforced by the server)
+- **Provision at the minimum possible size** — Zaakbrug stores only
+  Frank!Framework metadata + transient message-processing state and
+  has no high-volume tables. Use the smallest tier/storage SKU
+  permitted by the platform; scale up later from observed usage only
+  if needed.
 
 The chart sets `zaakbrug.connections.jdbc[0]` to point at the shared
 Postgres host with database `zaakbrug` / user `zaakbrug`; the password

--- a/charts/podiumd/docs/upgrade-from-4.7.1-to-4.7.2.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.1-to-4.7.2.md
@@ -1,0 +1,82 @@
+# Upgrade guide: PodiumD 4.7.1 → 4.7.2
+
+## Changes
+
+### Patch version for OIP
+
+Version of OIP goes from 2.1.2-rc to 2.1.2
+
+#### Action required
+
+No action required.
+
+### KISS: added Kennisbank role
+Added the Kennisbank role to the KISS-client. 
+
+#### Action required
+
+No action required.
+
+### Zaakbrug: new sub-chart
+
+The Zaakbrug Frank!Framework console is added as a new sub-chart
+(`wearefrank/zaakbrug` 2.3.26, application image `1.26.13`). It runs in
+the `podiumd` namespace as Deployment `podiumd-zaakbrug`, Service
+`podiumd-zaakbrug:80` → container port `8080`. Default JVM heap is
+`Xms=Xmx=4G` (`zaakbrug.frank.memory.{minimum,maximum}`); umbrella
+values now set matching K8s resource requests/limits (`5Gi`/`6Gi`
+memory, `250m`/`2` CPU). The sub-chart is disabled by default —
+environments that need it set `zaakbrug.enabled: true`.
+
+#### Action required
+
+Three parties must each do work before Zaakbrug will come up cleanly:
+
+**1. SSC — Postgres database**
+
+Create the `zaakbrug` database on the shared Postgres flexible server
+in the **normal fashion** (same procedure as for the other PodiumD
+component databases — `openzaak`, `openklant`, `ita`, etc.):
+
+- Database name: `zaakbrug`
+- Owner role: `zaakbrug`
+- Default privileges on the role for `public` schema
+- `ssl: true` (TLS enforced by the server)
+
+The chart sets `zaakbrug.connections.jdbc[0]` to point at the shared
+Postgres host with database `zaakbrug` / user `zaakbrug`; the password
+is supplied via the KeyVault secret listed below.
+
+**2. SSC — KeyVault secrets (terraform)**
+
+Add the following entries to the per-environment `keyvault.tfvars`
+`passwords` array (the standard `random_password` +
+`azurerm_key_vault_secret` loop generates a 32-char value once and
+never overwrites it):
+
+| KeyVault secret name | Used for | Pipeline env-var binding |
+|---|---|---|
+| `zaakbrug` | Postgres password for the `zaakbrug` DB user | `ZAAKBRUG_DATABASE_PASSWORD` |
+| `zaakbrug-oauth-client-secret` | Keycloak `zaakbrug` client secret (Frank!Framework console SSO + KC realm-config seed) | `ZAAKBRUG_OAUTH_CLIENT_SECRET` |
+| `zaakbrug-zaken-api-jwt-password` | JWT password for Zaakbrug's Zaken-API outbound credentials | `ZAAKBRUG_ZAKEN_API_JWT_PASSWORD` |
+
+The values file (`applications/gemeenten/<gemeente>/<env>/podiumd.yml`)
+already references these via `REP_ZAAKBRUG_DATABASE_PASSWORD_REP`,
+`REP_ZAAKBRUG_OAUTH_CLIENT_SECRET_REP` and
+`REP_ZAAKBRUG_ZAKEN_API_JWT_PASSWORD_REP` placeholders, which
+`patch_values.py` substitutes at deploy time from the env-var bindings
+above. No chart change is needed once the KV slots exist.
+
+**3. Customer (gemeente) — DNS**
+
+Create a CNAME record for the Zaakbrug hostname (default pattern
+`<env>-zaakbrug.<gemeente-domain>`, e.g. `ontw-zaakbrug.dimpact.nl`)
+pointing at the **Azure Application Gateway load balancer** that
+terminates ingress traffic for the cluster (the same LB the other
+PodiumD services already CNAME to). Without the DNS record, the
+Gateway API HTTPRoute (`hr-zaakbrug-nginx` on `public-gateway`) has no
+externally reachable hostname and OAuth2 callbacks from Keycloak will
+fail.
+
+The TLS certificate is issued automatically by cert-manager once the
+CNAME resolves — no manual certificate handling required.

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3369,3 +3369,14 @@ zaakbrug:
   enabled: false
   staging:
     enabled: false
+  # K8s cgroup limits sized for the Frank!Framework JVM heap (subchart
+  # default Xms=Xmx=4G via .Values.frank.memory.{minimum,maximum}).
+  # Overhead ≈1Gi headroom for non-heap (metaspace, code cache, direct
+  # buffers, threads). Env overlays may tune from observed usage.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 5Gi
+    limits:
+      cpu: "2"
+      memory: 6Gi


### PR DESCRIPTION
Adds the Zaakbrug Frank!Framework console as a new optional sub-chart in the PodiumD umbrella, plus chart-level defaults and upgrade documentation.

## Commits

- `feat(podiumd): add zaakbrug subchart (wearefrank/zaakbrug 2.3.26)`
- `docs(podiumd/images): add zaakbrug 1.26.13 to images-4.7.2 manifest (IN-1865)`
- `feat(podiumd/zaakbrug): set default cpu/memory requests + limits` — Burstable QoS sized for the JVM heap (Xms=Xmx=4G + ~1Gi non-heap overhead). Container was previously unbounded.
- `docs(podiumd): document Zaakbrug onboarding in 4.7.1 → 4.7.2 upgrade` — three-actor checklist: SSC DB, SSC KeyVault secrets (zaakbrug / zaakbrug-oauth-client-secret / zaakbrug-zaken-api-jwt-password), gemeente CNAME to Azure App Gateway LB.
- `docs(podiumd/zaakbrug): note DB should be minimum possible size`

## What stays default

`zaakbrug.enabled: false` — sub-chart is opt-in per environment. Existing envs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)