### PR TITLE
feature: monitoring-logging 1.0.14

### DIFF
--- a/charts/monitoring-logging/Chart.yaml
+++ b/charts/monitoring-logging/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: monitoring-logging
 description: A monitoring stack using Loki, Prometheus, Grafana Alloy, OpenTelemetry Collector, and Grafana. Optionally includes Grafana Tempo for distributed tracing.
 type: application
-version: 1.0.13
-appVersion: "1.0.13"
+version: 1.0.14
+appVersion: "1.0.14"
 dependencies:
   - name: loki
     repository: "@grafana"

--- a/charts/monitoring-logging/dashboards/logging-main-dashboard.json
+++ b/charts/monitoring-logging/dashboards/logging-main-dashboard.json
@@ -93,7 +93,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"openformulieren\"}\n        | json \n        | event = `submission_completed` \n        [$__range]\n    )\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"openformulieren\"}\n        |= \"submission_completed\"\n        | json event\n        | event = `submission_completed` \n        [$__range]\n    )\n) or vector(0)",
           "legendFormat": "Submissions",
           "queryType": "range",
           "refId": "A"
@@ -154,7 +154,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"openformulieren-worker\"}\n        | json \n        | event = `registration_success` \n        | action = `registrations.main_registration`\n        [$__range]\n    )\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"openformulieren-worker\"}\n        |= \"registration\"\n        | json event=\"event\", action=\"action\"\n        | event = `registration_success` \n        | action = `registrations.main_registration`\n        [$__range]\n    )\n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -214,7 +214,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"objecten\"}\n        | json \n        | event = `object_created` \n        [$__range]\n    ) or vector(0)\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"objecten\"}\n        |= \"object_created\"\n        | json event\n        | event = `object_created` \n        [$__range]\n    ) \n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -274,7 +274,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"opennotificaties-worker\"}\n        | json \n        | event=\"task_succeeded\"\n        [$__range]\n    )\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"opennotificaties-worker\"}\n        |= \"task_succeeded\"\n        | json event\n        | event=\"task_succeeded\"\n        [$__range]\n    )\n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -334,7 +334,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"openzaak\"}\n        | json \n        | event = `zaak_created` \n        [$__range]\n    ) or vector(0)\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"openzaak\"}\n        |= \"zaak_created\"\n        | json event\n        | event = `zaak_created` \n        [$__range]\n    ) \n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -394,7 +394,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum by (public_reference)(\n  count_over_time(\n    {app=\"openformulieren-worker\"}\n    | json\n    | event=\"registration_failure\"\n    | action=\"registrations.main_registration\"\n    [$__range]\n    ) \n)",
+          "expr": "sum by (public_reference)(\n  count_over_time(\n    {app=\"openformulieren-worker\"}\n    |= \"registration\"\n    | json event=\"event\", action=\"action\", public_reference=\"public_reference\"\n    | event=\"registration_failure\"\n    | action=\"registrations.main_registration\"\n    [$__range]\n    ) \n)",
           "queryType": "instant",
           "refId": "A"
         }
@@ -453,7 +453,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"objecten\"}\n        | json\n        | event = \"request_finished\"\n        | request = \"POST /api/v2/objects\"\n        | code >= 400\n        [$__range]\n    ) or vector(0)\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"objecten\"}\n        |= \"POST /api/v2/objects\"\n        | json event=\"event\", request=\"request\", code=\"code\"\n        | event = \"request_finished\"\n        | request = \"POST /api/v2/objects\"\n        | code >= 400\n        [$__range]\n    ) \n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -512,7 +512,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"opennotificaties-worker\"}\n        | json \n        | event=\"notification_failed\" or event=\"notification_error\"  \n        [$__range]\n    )\n    or vector(0)\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"opennotificaties-worker\"}\n        |= \"notification_\"\n        | json event\n        | event=~\"notification_failed|notification_error\"\n        [$__range]\n    )\n    \n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -572,7 +572,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum(\n    count_over_time (\n        {app=\"openzaak\"}\n        | json\n        | event = \"request_finished\"\n        | request = \"POST /zaken/api/v1/zaken\"\n        | code >= 400\n        [$__range]\n    ) or vector(0)\n) ",
+          "expr": "sum(\n    count_over_time (\n        {app=\"openzaak\"}\n        |= \"POST /zaken/api/v1/zaken\"\n        | json event=\"event\", request=\"request\", code=\"code\"\n        | event = \"request_finished\"\n        | request = \"POST /zaken/api/v1/zaken\"\n        | code >= 400\n        [$__range]\n    ) \n) or vector(0)",
           "queryType": "range",
           "refId": "A"
         }
@@ -716,7 +716,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum by(plugin, event) (\n  count_over_time(\n    {app=\"openformulieren-worker\"} \n    | json \n    | event=~\"registration_failure|registration_success\" \n    | trigger!=\"on_retry\"\n    |__error__=``\n    [$__range]\n  )\n)",
+          "expr": "count by (plugin, event) (\n  sum by (plugin, event, public_reference) (\n    count_over_time(\n      {app=\"openformulieren-worker\"}\n      |= \"registration_\"\n      | json event=\"event\", plugin=\"plugin\", public_reference=\"public_reference\", trigger=\"trigger\"\n      | event=~\"registration_failure|registration_success\"\n      [$__range]\n    )\n  )\n)",
           "legendFormat": "",
           "queryType": "instant",
           "refId": "A"
@@ -819,7 +819,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum by(subscription_callback, resource) (\n  count_over_time(\n    {app=\"opennotificaties-worker\"} \n    | json \n    | event=\"notification_successful\" \n    |__error__=``\n    [$__range]\n  )\n)",
+          "expr": "sum by(subscription_callback, resource) (\n  count_over_time(\n    {app=\"opennotificaties-worker\"} \n    |=\"notification_successful\"\n    | json event=\"event\", subscription_callback=\"subscription_callback\", resource=\"resource\"\n    | event=\"notification_successful\" \n    [$__range]\n  )\n)",
           "legendFormat": "",
           "queryType": "instant",
           "refId": "A"
@@ -892,7 +892,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": "/[4-5].*/"
+              "options": "/^[4-5].*/"
             },
             "properties": [
               {
@@ -940,7 +940,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "sum by (path, status)(\n    count_over_time (\n        {app=\"openzaak\"}\n        | json \n        | event = \"request\"\n        | method != \"GET\"\n        | method != \"HEAD\"                 \n        [$__range]\n    )\n) \n\n",
+          "expr": "sum by (path, status)(\n    count_over_time (\n        {app=\"openzaak\"}\n        |= \"request\"\n        |= \"/api/\"\n        | json event=\"event\", method=\"method\", path=\"path\", status=\"status\"\n        | event = \"request\"\n        | path=~\".*/api/.*\"\n        | method!~\"GET|HEAD\"\n        | label_format path=`{{ regexReplaceAllLiteral \"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\" .path \"<uuid>\" }}`                \n        [$__range]\n    )\n) \n\n",
           "queryType": "instant",
           "refId": "A"
         }
@@ -1046,7 +1046,7 @@
           },
           "direction": "backward",
           "editorMode": "code",
-          "expr": "{app=\"openformulieren-worker\"} \n| json \n| action=\"registrations.main_registration\", event=\"registration_success\"",
+          "expr": "{app=\"openformulieren-worker\"}\n|= \"registration_success\"\n| json \n| event=\"registration_success\"\n| action=\"registrations.main_registration\"",
           "queryType": "range",
           "refId": "B"
         }
@@ -1377,7 +1377,7 @@
               },
               "direction": "backward",
               "editorMode": "code",
-              "expr": "{app=\"objecten\"} | json | event = \"object_created\"",
+              "expr": "{app=\"objecten\"}\n|= \"object_created\"\n| json event=\"event\", object_uuid=\"object_uuid\", token_identifier=\"token_identifier\"\n| event = \"object_created\"",
               "queryType": "range",
               "refId": "A"
             }
@@ -1497,7 +1497,7 @@
               },
               "direction": "backward",
               "editorMode": "code",
-              "expr": "{app=\"objecten\"}\n| json\n| event = \"request_finished\"\n| request = \"POST /api/v2/objects\"\n| code >= 400",
+              "expr": "{app=\"objecten\"}\n|= \"POST /api/v2/objects\"\n| json event=\"event\", request=\"request\", code=\"code\", request_id=\"request_id\"\n| event = \"request_finished\"\n| request = \"POST /api/v2/objects\"\n| code >= 400",
               "queryType": "range",
               "refId": "A"
             }
@@ -1627,7 +1627,7 @@
         {
           "direction": "backward",
           "editorMode": "code",
-          "expr": "{app=\"opennotificaties-worker\"}\n| json \n| event=\"notification_successful\"\n",
+          "expr": "{app=\"opennotificaties-worker\"}\n|= \"notification_successful\"\n| json  event=\"event\", subscription_callback=\"subscription_callback\", channel_name=\"channel_name\", action=\"action\", resource=\"resource\", resource_url=\"resource_url\"\n| event=\"notification_successful\"\n",
           "queryType": "range",
           "refId": "A"
         }
@@ -1743,7 +1743,7 @@
           },
           "direction": "backward",
           "editorMode": "code",
-          "expr": "{app=\"opennotificaties-worker\"} \n| json \n| event=\"notification_failed\" or event=\"notification_error\"  ",
+          "expr": "{app=\"opennotificaties-worker\"}\n|= \"notification_\"\n| json event=\"event\", resource=\"resource\", action=\"action\", resource_url=\"resource_url\", subscription_callback=\"subscription_callback\", channel_name=\"channel_name\", task_attempt_count=\"task_attempt_count\", http_status_code=\"http_status_code\"\n| event=~\"notification_failed|notification_error\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -1897,7 +1897,7 @@
           },
           "direction": "backward",
           "editorMode": "code",
-          "expr": "{app=\"openzaak\"} | json | event=\"zaak_created\"",
+          "expr": "{app=\"openzaak\"} \n|= \"zaak_created\"\n| json event=\"event\", identificatie=\"identificatie\", zaaktype=\"zaaktype\"\n| event=\"zaak_created\"",
           "queryType": "range",
           "refId": "E"
         }
@@ -2000,7 +2000,7 @@
           },
           "direction": "backward",
           "editorMode": "code",
-          "expr": "{app=\"openzaak\"}\n| json\n| event = \"request_finished\"\n| request !~ `GET .*` \n| event = `request_finished` \n| code =~ `[4-5].*`",
+          "expr": "{app=\"openzaak\"}\n|= \"POST /zaken/api/v1/zaken\"\n| json event=\"event\", request=\"request\", code=\"code\", request_id=\"request_id\"\n| event = \"request_finished\"\n| request = \"POST /zaken/api/v1/zaken\"\n| code >= 400",
           "queryType": "range",
           "refId": "A"
         }
@@ -2075,7 +2075,7 @@
   ],
   "preload": false,
   "refresh": "5m",
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": []
@@ -2088,5 +2088,5 @@
   "timezone": "",
   "title": "Monitoring en logging (with structlog)",
   "uid": "cawvpt6dd",
-  "version": 0
+  "version": 1
 }

--- a/charts/monitoring-logging/dashboards/logging-main-dashboard.json
+++ b/charts/monitoring-logging/dashboards/logging-main-dashboard.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 0,
+  "id": 170685764591616,
   "links": [],
   "panels": [
     {
@@ -57,7 +57,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -88,7 +89,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -118,7 +119,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -149,7 +151,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -178,7 +180,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -209,7 +212,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -238,7 +241,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -269,7 +273,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -298,7 +302,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -329,7 +334,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -358,7 +363,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               }
             ]
           }
@@ -389,7 +395,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -417,7 +423,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               }
             ]
           }
@@ -448,7 +455,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -476,7 +483,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               }
             ]
           }
@@ -507,7 +515,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -536,7 +544,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               }
             ]
           }
@@ -567,7 +576,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -631,7 +640,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -685,7 +695,7 @@
         "h": 9,
         "w": 10,
         "x": 0,
-        "y": 8
+        "y": 12
       },
       "id": 99,
       "options": {
@@ -711,7 +721,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -773,7 +783,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -788,7 +799,7 @@
         "h": 9,
         "w": 14,
         "x": 10,
-        "y": 8
+        "y": 12
       },
       "id": 122,
       "options": {
@@ -814,7 +825,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -882,7 +893,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               }
             ]
           },
@@ -910,7 +922,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 21
       },
       "id": 104,
       "options": {
@@ -935,7 +947,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -964,7 +976,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 29
       },
       "id": 69,
       "panels": [],
@@ -986,6 +998,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -993,7 +1008,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1021,23 +1037,15 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 30
       },
       "id": 61,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "datasource": {
@@ -1124,6 +1132,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1131,7 +1142,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1171,23 +1183,15 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 35
       },
       "id": 89,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "datasource": {
@@ -1306,256 +1310,459 @@
       "type": "table"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 41
       },
       "id": 81,
-      "panels": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 108
-          },
-          "id": 85,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
-          },
-          "pluginVersion": "12.1.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "loki",
-                "uid": "loki"
-              },
-              "direction": "backward",
-              "editorMode": "code",
-              "expr": "{app=\"objecten\"}\n|= \"object_created\"\n| json event=\"event\", object_uuid=\"object_uuid\", token_identifier=\"token_identifier\"\n| event = \"object_created\"",
-              "queryType": "range",
-              "refId": "A"
-            }
-          ],
-          "title": "Created objects",
-          "transformations": [
-            {
-              "id": "extractFields",
-              "options": {
-                "delimiter": ",",
-                "format": "json",
-                "jsonPaths": [
-                  {
-                    "alias": "Object",
-                    "path": "object_uuid"
-                  },
-                  {
-                    "alias": "Client",
-                    "path": "token_identifier"
-                  },
-                  {
-                    "alias": "Objecttype",
-                    "path": "objecttype_uuid"
-                  }
-                ],
-                "source": "labels"
-              }
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Line": true,
-                  "Objecttype": true,
-                  "id": true,
-                  "labelTypes": true,
-                  "labels": true,
-                  "tsNs": true
-                },
-                "includeByName": {},
-                "indexByName": {
-                  "Client": 8,
-                  "Line": 2,
-                  "Object": 6,
-                  "Objecttype": 7,
-                  "Time": 1,
-                  "id": 5,
-                  "labelTypes": 4,
-                  "labels": 0,
-                  "tsNs": 3
-                },
-                "renameByName": {}
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 114
-          },
-          "id": 90,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
-          },
-          "pluginVersion": "12.1.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "loki",
-                "uid": "loki"
-              },
-              "direction": "backward",
-              "editorMode": "code",
-              "expr": "{app=\"objecten\"}\n|= \"POST /api/v2/objects\"\n| json event=\"event\", request=\"request\", code=\"code\", request_id=\"request_id\"\n| event = \"request_finished\"\n| request = \"POST /api/v2/objects\"\n| code >= 400",
-              "queryType": "range",
-              "refId": "A"
-            }
-          ],
-          "title": "Failures",
-          "transformations": [
-            {
-              "id": "extractFields",
-              "options": {
-                "format": "json",
-                "jsonPaths": [
-                  {
-                    "alias": "Code",
-                    "path": "code"
-                  },
-                  {
-                    "alias": "Request Id",
-                    "path": "request_id"
-                  }
-                ],
-                "source": "labels"
-              }
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Line": true,
-                  "app": true,
-                  "client": true,
-                  "code": false,
-                  "container": true,
-                  "detected_level": true,
-                  "event": true,
-                  "id": true,
-                  "instance": true,
-                  "labelTypes": true,
-                  "labels": true,
-                  "level": true,
-                  "logger": true,
-                  "logstream": true,
-                  "request": true,
-                  "service_name": true,
-                  "target": true,
-                  "timestamp": true,
-                  "tsNs": true
-                },
-                "includeByName": {},
-                "indexByName": {},
-                "renameByName": {}
-              }
-            }
-          ],
-          "type": "table"
-        }
-      ],
+      "panels": [],
       "title": "Objects API",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 85,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0-17814087142",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{app=\"objecten\"}\n|= \"object_created\"\n| json event=\"event\", object_uuid=\"object_uuid\", token_identifier=\"token_identifier\"\n| event = \"object_created\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Created objects",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "jsonPaths": [
+              {
+                "alias": "Object",
+                "path": "object_uuid"
+              },
+              {
+                "alias": "Client",
+                "path": "token_identifier"
+              },
+              {
+                "alias": "Objecttype",
+                "path": "objecttype_uuid"
+              }
+            ],
+            "source": "labels"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Line": true,
+              "Objecttype": true,
+              "id": true,
+              "labelTypes": true,
+              "labels": true,
+              "tsNs": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Client": 8,
+              "Line": 2,
+              "Object": 6,
+              "Objecttype": 7,
+              "Time": 1,
+              "id": 5,
+              "labelTypes": 4,
+              "labels": 0,
+              "tsNs": 3
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Code"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 279
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Request Id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 345
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Line"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 1578
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 90,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0-17814087142",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{app=\"objecten\"}\n| json event=\"event\", request=\"request\", code=\"code\", request_id=\"request_id\", title=\"title\"\n| event=\"request_finished\"\n| request=\"POST /api/v2/objects\"\n| code >= 400",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Failures",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "jsonPaths": [
+              {
+                "alias": "Code",
+                "path": "code"
+              },
+              {
+                "alias": "Request Id",
+                "path": "request_id"
+              }
+            ],
+            "source": "labels"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Line": true,
+              "app": true,
+              "client": true,
+              "code": false,
+              "container": true,
+              "detected_level": true,
+              "event": true,
+              "id": true,
+              "instance": true,
+              "labelTypes": true,
+              "labels": true,
+              "level": true,
+              "logger": true,
+              "logstream": true,
+              "request": true,
+              "service_name": true,
+              "target": true,
+              "timestamp": true,
+              "tsNs": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Code"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 279
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Request Id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 345
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Line"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 847
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 127,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0-17814087142",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{app=\"objecten\"}\n| json\n| event=\"api.handled_exception\"\n| status >= 400",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "All errors in Objects API",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "jsonPaths": [
+              {
+                "alias": "Code",
+                "path": "code"
+              },
+              {
+                "alias": "Request Id",
+                "path": "request_id"
+              },
+              {
+                "alias": "Detail",
+                "path": "data.detail"
+              },
+              {
+                "alias": "Title",
+                "path": "title"
+              },
+              {
+                "alias": "Status",
+                "path": "status"
+              }
+            ],
+            "source": "Line"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Detail": true,
+              "Line": true,
+              "app": true,
+              "client": true,
+              "code": false,
+              "container": true,
+              "detected_level": true,
+              "event": true,
+              "id": true,
+              "instance": true,
+              "labelTypes": true,
+              "labels": true,
+              "level": true,
+              "logger": true,
+              "logstream": true,
+              "request": true,
+              "service_name": true,
+              "target": true,
+              "timestamp": true,
+              "tsNs": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Code": 8,
+              "Detail": 9,
+              "Line": 4,
+              "Request Id": 2,
+              "Status": 3,
+              "Time": 1,
+              "Title": 10,
+              "id": 7,
+              "labelTypes": 6,
+              "labels": 0,
+              "tsNs": 5
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -1563,7 +1770,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 65
       },
       "id": 82,
       "panels": [],
@@ -1585,6 +1792,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1592,7 +1802,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1607,22 +1818,14 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 66
       },
       "id": 98,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "direction": "backward",
@@ -1697,6 +1900,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1704,7 +1910,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1719,22 +1926,14 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 71
       },
       "id": 97,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "datasource": {
@@ -1828,7 +2027,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 75
       },
       "id": 94,
       "panels": [],
@@ -1851,6 +2050,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1858,7 +2060,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1873,22 +2076,14 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 76
       },
       "id": 75,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "datasource": {
@@ -1954,6 +2149,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1961,7 +2159,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1976,22 +2175,14 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 83
       },
       "id": 91,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.3.0-17814087142",
       "targets": [
         {
           "datasource": {

--- a/charts/monitoring-logging/dashboards/logging-main-dashboard.json
+++ b/charts/monitoring-logging/dashboards/logging-main-dashboard.json
@@ -597,6 +597,88 @@
         "x": 0,
         "y": 7
       },
+      "id": 126,
+      "panels": [],
+      "title": "Alerts",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "in %",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 8
+      },
+      "id": 125,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0-17814087142",
+      "targets": [
+        {
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "1 - sum(\n    count_over_time (\n        {app=\"openformulieren-worker\"}\n        |= \"registration\"\n        | json event=\"event\", action=\"action\"\n        | event = `registration_success` \n        | action = `registrations.main_registration`\n        [1h]\n    )\n) / sum(\n    count_over_time (\n        {app=\"openformulieren\"}\n        |= \"submission_completed\"\n        | json event\n        | event = `submission_completed` \n        [1h]\n    )\n)",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "OF failure rate for 1h",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
       "id": 102,
       "panels": [],
       "title": "Detailed summary",

--- a/charts/monitoring-logging/dashboards/meta.json
+++ b/charts/monitoring-logging/dashboards/meta.json
@@ -1,0 +1,66 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Meta information about M&L release, including the release version. ",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 0,
+  "links": [],
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "## Release version: {{ .Chart.Version }}",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.3.0-17814087142",
+      "title": "Monitoring & Logging",
+      "type": "text"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Meta",
+  "uid": "anwfnd7",
+  "version": 4
+}

--- a/charts/monitoring-logging/templates/meta.yaml
+++ b/charts/monitoring-logging/templates/meta.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.grafana.dashboardsConfigMaps.meta }}
+data:
+  meta.json: |-
+{{ .Files.Get "dashboards/meta.json" | indent 4 }}

--- a/charts/monitoring-logging/values.yaml
+++ b/charts/monitoring-logging/values.yaml
@@ -733,6 +733,7 @@ loki:
       max_global_streams_per_user: 5000
       max_query_length: 721h # 1 month. Default: 721h
       max_query_parallelism: 48 # Utilize Azure's high throughput
+      max_query_series: 5000 # Default: 500
       max_streams_per_user: 0 # Old Default: 10000
       split_queries_by_interval: 15m # Smaller splits = faster parallelization
       max_cache_freshness_per_query: 10m

--- a/charts/monitoring-logging/values.yaml
+++ b/charts/monitoring-logging/values.yaml
@@ -78,6 +78,16 @@ grafana:
     dashboardproviders.yaml:
       apiVersion: 1
       providers:
+        - name: "meta"
+          orgId: 1
+          folder: "PodiumD_Monitoring_Logging"
+          type: file
+          disableDeletion: false
+          updateIntervalSeconds: 30
+          allowUiUpdates: true
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/meta
         - name: "default"
           orgId: 1
           folder: 'PodiumD_Monitoring_Logging'
@@ -121,6 +131,7 @@ grafana:
 
   # -- Dashboard opgenomen in ConfigMap
   dashboardsConfigMaps:
+    meta: "meta"
     default: "logging-main-dashboard"
     logs: "logging-logs"
     metrics: "monitoring-metrics-dashboards"


### PR DESCRIPTION
Release-branch placeholder for monitoring-logging 1.0.14 (next patch on the 1.0.x line; previous release `monitoring-logging-1.0.13` was cut from PR #298 IN-1929).

## Contents

- `chore(monitoring-logging): bump chart version to 1.0.14` — Chart.yaml `version` + `appVersion` only.
- implement Spike for IN-2063  https://dimpact.atlassian.net/browse/IN-2151: 
    - optimize dashboard queries 
    - increase a limit on the single query return 

## Policy

- One open monitoring-logging release branch + PR at a time (see `project_monitoring_logging_branch_workflow.md` in claude memory).
- This PR stays in **draft** until a reviewer is requested (per `project_release_pr_draft_policy.md`).

## Test plan

- [ ] helm lint
- [ ] helm template renders cleanly
- [ ] tracking PRs / Renovate stack as patches land