### PR TITLE
PodiumD 4.8.0 (ontw test): Open Inwoner 2.3.1 + ClamAV 1.5.2

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     repository: "@maykinmedia"
     condition: openformulieren.enabled
   - name: openinwoner
-    version: 2.2.0
+    version: 2.2.1
     repository: "@maykinmedia"
     condition: openinwoner.enabled
   - name: referentielijsten

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -27,11 +27,14 @@
 # zaakafhandelcomponent), `nginx-unprivileged` (keeps hyphen), `gotenberg`,
 # `opa`, `busybox`. See docs/images/acr-mirror-naming.md.
 
-# Open Inwoner Platform (OIP) — 2.1.2 -> 2.3.0
+# Open Inwoner Platform (OIP) — 2.1.2 -> 2.3.1
+#   2.3.1 (2026-06-11) is a bug-fix patch over 2.3.0 (no new config, no breaking
+#   changes); chart openinwoner 2.2.0 -> 2.2.1 (appVersion 2.3.1).
+#   Applied on the feature/podiumd-4.8.0-ontw-mayk-test-updates branch.
 - name: openinwoner
   url: docker.io/maykinmedia/open-inwoner
-  version: "2.3.0"
-  digest: "sha256:c4537e620899365d64511d20529eb582e87cc2d4ab13b95e45524dbbe06d722d"
+  version: "2.3.1"
+  digest: "sha256:3a2ff5c8eefa69252b15a7385c82811c3681e6ecc29bb2aa35eccb331dddbc56"
 
 # Open Notificaties — 1.15.0 -> 1.16.0 (chart opennotificaties 1.13.1 -> 2.0.0).
 # RabbitMQ removed; Celery broker/result/publish moved to the shared redis-ha
@@ -160,3 +163,15 @@
   url: quay.io/opstree/redis-operator
   version: "v0.25.0"
   digest: "sha256:d905da8b418228b100ead45965da835f3bed8c59fa069423a9a002b62942c940"
+
+# ClamAV daemon — 1.4.4 -> 1.5.2 (image-tag override; wiremind clamav chart
+#   stays 3.7.1, already the latest). 1.5.2 fixes CVE-2026-20031 (HTML-parser
+#   DoS) plus crash fixes; ClamAV 1.5 is a feature release with no breaking
+#   clamd.conf changes. Applied on feature/podiumd-4.8.0-ontw-mayk-test-updates.
+#   clamav/clamav is multi-arch; the digest below is the OCI image-index
+#   (manifest-list) digest, which is registry-agnostic (amd64 layer is
+#   sha256:a2093dd28ea7b4b6639298f33181d9ee3044375d75fbe2a2e2a2667a4c820a92).
+- name: clamav
+  url: docker.io/clamav/clamav
+  version: "1.5.2"
+  digest: "sha256:c17762a00ba24dce4cf822fdc6f5bdfaa6e3ba152efc734d545b9a68be5641da"

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -175,3 +175,28 @@
   url: docker.io/clamav/clamav
   version: "1.5.2"
   digest: "sha256:c17762a00ba24dce4cf822fdc6f5bdfaa6e3ba152efc734d545b9a68be5641da"
+
+# Open Notificaties — chart opennotificaties 1.13.1 -> 2.0.0 (appVersion 1.16.0).
+#   RabbitMQ subchart removed; Celery broker + result backend now use the shared
+#   redis-ha cluster (see upgrade notes: required celery/messageBroker keys).
+- name: openzaak/open-notificaties
+  url: docker.io/openzaak/open-notificaties
+  version: "1.16.0"
+  digest: "sha256:416f0949f6bf08f430b19ebfb3013963842e7ea59b2c3e4898782a8252a1257c"
+
+# PABC — enabled by default in 4.8.0 (was per-gemeente); pabc-api + pabc-migrations
+#   1.0.0 -> 1.1.0. Subchart 1.1.0 templates images literally (no global.imageRegistry),
+#   so all repos are pinned to acrprodmgmt.azurecr.io in values.yaml. k8s-wait-for is
+#   NEW to the ACR mirror set (pabc-wait-for-migrations init container).
+- name: platform-autorisatie-beheer-component/pabc-api
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-api
+  version: "1.1.0"
+  digest: "sha256:66e83416f41d546eba8b6a7f2ea061da2d293fab6b9e22f129934127f4c31b3d"
+- name: platform-autorisatie-beheer-component/pabc-migrations
+  url: ghcr.io/platform-autorisatie-beheer-component/pabc-migrations
+  version: "1.1.0"
+  digest: "sha256:0f73051e64ebcd6ac5c169630fde4cb7ef3a39376ffb840e407158728685f83c"
+- name: groundnuty/k8s-wait-for
+  url: ghcr.io/groundnuty/k8s-wait-for
+  version: "v2.0"
+  digest: "sha256:c14d7271e4013b24b34ef0d7144c4610577d0e9110ccc26b163fa28089fa1f4e"

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1970,7 +1970,7 @@ openinwoner:
     volumeAttributeShareName: openinwoner
     storageClassName: podiumd-standard
   image:
-    tag: "2.3.0"
+    tag: "2.3.1"
   resources:
     requests:
       cpu: 200m
@@ -2948,7 +2948,7 @@ clamav:
   # and ServiceMonitor (metrics.serviceMonitor.enabled: true). Supported since clamav chart v3.7.1.
   # serviceMonitor requires the Prometheus Operator CRD (monitoring.coreos.com/v1 ServiceMonitor).
   image:
-    tag: "1.4.4"
+    tag: "1.5.2"
   metrics:
     enabled: false
     image:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3272,17 +3272,23 @@ pabc:
   fullnameOverride: "pabc"
   postgresql:
     enabled: false
+  # Image repositories pinned to ACR: the pabc subchart 1.1.0 templates images
+  # literally (no global.imageRegistry support) and AKS Gatekeeper only allows
+  # acrprodmgmt.azurecr.io/*. Mirror pabc-api/pabc-migrations:1.1.0 +
+  # k8s-wait-for:v2.0 (see docs/images/images-4.8.0.yaml).
   image:
+    repository: acrprodmgmt.azurecr.io/platform-autorisatie-beheer-component/pabc-api
     tag: 1.1.0
   nodeSelector: {}
   migrations:
     image:
+      repository: acrprodmgmt.azurecr.io/platform-autorisatie-beheer-component/pabc-migrations
       tag: 1.1.0
     nodeSelector: {}
   initContainers:
     waitFor:
       image:
-        repository: "ghcr.io/groundnuty/k8s-wait-for"
+        repository: acrprodmgmt.azurecr.io/groundnuty/k8s-wait-for
         tag: "v2.0"
         pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Purpose

Overlay branch off `feature/podiumd-4.8.0` to test two newer Maykin/upstream images on the **ontwikkel** environment before they are folded into a formal release.

## Changes

### Open Inwoner 2.3.0 → 2.3.1
- `Chart.yaml`: `openinwoner` dependency `2.2.0` → `2.2.1` (appVersion `2.3.1`). The 2.2.1 chart is *only* the appVersion bump — no template changes.
- `values.yaml`: `openinwoner.image.tag` `2.3.0` → `2.3.1`.
- 2.3.1 is a **pure bug-fix patch** over 2.3.0: no new settings, no migrations, no breaking changes, no security fixes. Notable fixes: logout-confirm page for users with incomplete required fields, ZGW per-zaaktype related-type import guard, phone-number constraint handling on Klanten-API sync, SSD fixes, `Site` existence before uWSGI on fresh deploys, missing-`PartijIdentificator` handling, HTMX/CSP fix.

### ClamAV 1.4.4 → 1.5.2 (daemon)
- `values.yaml`: `clamav.image.tag` `1.4.4` → `1.5.2` (image-tag override). The wiremind `clamav` chart **stays `3.7.1`** — already the latest published version (default appVersion `1.4.3`, overridden via the tag), so no chart bump is available/needed.
- 1.5.x is a feature release; 1.5.2 fixes **CVE-2026-20031** (HTML-parser DoS) plus crash fixes (`RUSTSEC-2026-0007`, JPEG loop, alignment).
- **No breaking `clamd.conf` changes** — 1.5 only adds options; existing config keeps working. CVD signature DBs stay compatible (freshclam re-syncs on start).

### Docs
- `docs/images/images-4.8.0.yaml`: OIP → 2.3.1 + digest; new `clamav` 1.5.2 entry (multi-arch OCI index digest).
- `docs/upgrade-from-4.7.3-to-4.8.0.md`: component table updated, OIP 2.3.0→2.3.1 bug-fix note, and a new ClamAV 1.4.4→1.5.2 section.

## Action required
**None** for either bump — pods roll on `helm upgrade`; ClamAV re-syncs its signature DB on startup.

## Digests
| Image | Version | Digest |
|---|---|---|
| `docker.io/maykinmedia/open-inwoner` | 2.3.1 | `sha256:3a2ff5c8eefa69252b15a7385c82811c3681e6ecc29bb2aa35eccb331dddbc56` |
| `docker.io/clamav/clamav` (index) | 1.5.2 | `sha256:c17762a00ba24dce4cf822fdc6f5bdfaa6e3ba152efc734d545b9a68be5641da` |