### PR TITLE
PodiumD 4.7.6: revert Open Formulieren request logging + upgrade guides

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.7.5
-appVersion: "4.7.5"
+version: 4.7.6
+appVersion: "4.7.6"
 dependencies:
   - name: keycloak-operator
     version: 1.12.0

--- a/charts/podiumd/docs/UPGRADING.md
+++ b/charts/podiumd/docs/UPGRADING.md
@@ -7,7 +7,7 @@ files required for each hop, and which guides are reference-only.
 ## Official upgrade path
 
 ```
-4.5.15 ─▶ 4.5.16 ─▶ 4.6.4 ─▶ 4.6.8 ─▶ 4.7.3 ─▶ 4.7.4
+4.5.15 ─▶ 4.5.16 ─▶ 4.6.4 ─▶ 4.6.8 ─▶ 4.7.3 ─▶ 4.7.4 ─▶ 4.7.5 ─▶ 4.7.6
 ```
 
 Upgrade one hop at a time, in order. Each hop has exactly **one** upgrade guide
@@ -20,6 +20,8 @@ and a matching image manifest (the ACR-mirror set for that hop):
 | 4.6.4 → 4.6.8   | [`upgrade-from-4.6.4-to-4.6.8.md`](upgrade-from-4.6.4-to-4.6.8.md)   | [`images/images-4.6.8.yaml`](images/images-4.6.8.yaml) |
 | 4.6.8 → 4.7.3   | [`upgrade-from-4.6.8-to-4.7.3.md`](upgrade-from-4.6.8-to-4.7.3.md)   | 4.7 chain: [`images-4.7.0`](images/images-4.7.0.yaml) · [`4.7.1`](images/images-4.7.1.yaml) · [`4.7.2`](images/images-4.7.2.yaml) · [`4.7.3`](images/images-4.7.3.yaml) |
 | 4.7.3 → 4.7.4   | [`upgrade-from-4.7.3-to-4.7.4.md`](upgrade-from-4.7.3-to-4.7.4.md)   | [`images/images-4.7.4.yaml`](images/images-4.7.4.yaml) |
+| 4.7.4 → 4.7.5   | [`upgrade-from-4.7.4-to-4.7.5.md`](upgrade-from-4.7.4-to-4.7.5.md)   | [`images/images-4.7.5.yaml`](images/images-4.7.5.yaml) |
+| 4.7.5 → 4.7.6   | [`upgrade-from-4.7.5-to-4.7.6.md`](upgrade-from-4.7.5-to-4.7.6.md)   | — (docs/config only, no image changes) |
 
 > The 4.6.4 → 4.6.8 and 4.6.8 → 4.7.3 guides are **consolidated**: each folds
 > several intermediate releases into one document so an operator reads one

--- a/charts/podiumd/docs/upgrade-from-4.6.6-to-4.7.3.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.6-to-4.7.3.md
@@ -408,7 +408,7 @@ openarchiefbeheer:
           header_value: "Token REP_OBJECTEN_CREDENTIALS_OPENARCHIEFBEHEER_TOKEN_REP"
         - identifier: klanten-api
           label: Klanten API
-          api_root: https://opeklant.example.com/klantinteracties/api/v1/
+          api_root: https://openklant.example.com/klantinteracties/api/v1/
           api_type: kc
           auth_type: api_key
           header_key: Authorization

--- a/charts/podiumd/docs/upgrade-from-4.6.8-to-4.7.3.md
+++ b/charts/podiumd/docs/upgrade-from-4.6.8-to-4.7.3.md
@@ -399,7 +399,7 @@ openarchiefbeheer:
           header_value: "Token REP_OBJECTEN_CREDENTIALS_OPENARCHIEFBEHEER_TOKEN_REP"
         - identifier: klanten-api
           label: Klanten API
-          api_root: https://opeklant.example.com/klantinteracties/api/v1/
+          api_root: https://openklant.example.com/klantinteracties/api/v1/
           api_type: kc
           auth_type: api_key
           header_key: Authorization

--- a/charts/podiumd/docs/upgrade-from-4.7.2-to-4.7.3.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.2-to-4.7.3.md
@@ -125,7 +125,7 @@ openarchiefbeheer:
           header_value: "Token REP_OBJECTEN_CREDENTIALS_OPENARCHIEFBEHEER_TOKEN_REP"
         - identifier: klanten-api
           label: Klanten API
-          api_root: https://opeklant.example.com/klantinteracties/api/v1/
+          api_root: https://openklant.example.com/klantinteracties/api/v1/
           api_type: kc
           auth_type: api_key
           header_key: Authorization

--- a/charts/podiumd/docs/upgrade-from-4.7.4-to-4.7.5.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.4-to-4.7.5.md
@@ -1,0 +1,29 @@
+# Upgrade guide: PodiumD 4.7.4 → 4.7.5
+
+4.7.5 is a small patch release: it bumps the **ZGW Office Add-in** only. No
+other components change.
+
+## Changes
+
+### ZGW Office Add-in `v0.9.289` → `v0.9.313`
+
+- `zgw-office-addin` chart dependency `0.0.87` → `0.0.88` in
+  `charts/podiumd/Chart.yaml`.
+- Frontend and backend images bumped to `v0.9.313` (digest-pinned) in
+  `charts/podiumd/values.yaml`.
+- **Image repository names changed** `…-add-in-…` → `…-addin-…`:
+  - `ghcr.io/infonl/zgw-office-addin-frontend`
+  - `ghcr.io/infonl/zgw-office-addin-backend`
+
+Image / digests: see [`docs/images/images-4.7.5.yaml`](images/images-4.7.5.yaml).
+
+#### Action required
+
+- **Standard image-pin update** — pins are already in `values.yaml` and
+  `images/images-4.7.5.yaml`.
+- **ACR-mirror environments:** because the repository names changed from
+  `add-in` to `addin`, mirror the **new** repository names/tags
+  (`zgw-office-addin-frontend` / `zgw-office-addin-backend` at `v0.9.313`).
+  An existing mirror of the old `add-in` repositories will not be used by the
+  new pins.
+- No config, schema, or migration changes.

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.7.6.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.7.6.md
@@ -80,6 +80,34 @@ documented in [`upgrade-from-4.7.3-to-4.7.4.md`](upgrade-from-4.7.3-to-4.7.4.md)
 [`openarchiefbeheer-known-issues.md`](openarchiefbeheer-known-issues.md) for
 other OAB configuration traps.
 
+### Open Formulieren — outgoing request logging re-enabled (revert of 4.7.4)
+
+4.7.4 introduced `LOG_OUTGOING_REQUESTS=False` in `openformulieren.extraEnvVars` to
+disable outgoing/external HTTP request logging by default. After further analysis this
+override is **removed in 4.7.6**, reverting Open Formulieren to the upstream default
+(`LOG_OUTGOING_REQUESTS=True` — logging enabled).
+
+After upgrading, Open Formulieren pods will restart and outgoing requests will be
+logged again (both the stdout handler and, if configured, the DB-save handler).
+
+#### Action required
+
+Operators who want to **keep outgoing request logging disabled** (the 4.7.4 behaviour)
+must add the override in their per-gemeente `podiumd.yml`:
+
+```yaml
+openformulieren:
+  extraEnvVars:
+    - name: LOG_OUTGOING_REQUESTS
+      value: "False"
+```
+
+No action is needed if logging outgoing requests is acceptable.
+
+See [`upgrade-from-4.7.3-to-4.7.4.md`](upgrade-from-4.7.3-to-4.7.4.md) for the full
+background on what `LOG_OUTGOING_REQUESTS` controls and how the DB-save handler
+interacts with it.
+
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 
 Open Beheer reads object types from the **Objecttypen API** and authenticates

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.7.6.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.7.6.md
@@ -79,3 +79,67 @@ documented in [`upgrade-from-4.7.3-to-4.7.4.md`](upgrade-from-4.7.3-to-4.7.4.md)
 4.7.6 only corrects/completes the in-repo example. See
 [`openarchiefbeheer-known-issues.md`](openarchiefbeheer-known-issues.md) for
 other OAB configuration traps.
+
+### Open Beheer ↔ Objecttypen API token (IN-2345)
+
+Open Beheer reads object types from the **Objecttypen API** and authenticates
+with an API token. The token must be configured **on both sides with the exact
+same secret**, `REP_OBJECTTYPEN_OPENBEHEER_TOKEN_REP` (Key Vault
+`objecttypen-openbeheer-token`, pipeline var `OBJECTTYPEN_OPENBEHEER_TOKEN`):
+
+- **Objecttypen** — a `tokenauth` item that grants Open Beheer the token:
+
+  ```yaml
+  objecttypen:
+    configuration:
+      data: |-
+        tokenauth_config_enable: true
+        tokenauth:
+          items:
+            - identifier: openbeheer
+              token: {value_from: {env: objecttypen_openbeheer_token}}   # REP_OBJECTTYPEN_OPENBEHEER_TOKEN_REP
+              contact_person: Dimpact
+              email: servicedesk@dimpact.nl
+  ```
+
+- **Open Beheer** — the `objecttypen-service` consumer that *uses* the token.
+  The header value **must** carry the literal `Token ` prefix:
+
+  ```yaml
+  openbeheer:
+    configuration:
+      data: |-
+        zgw_consumers:
+          services:
+            - identifier: objecttypen-service
+              api_root: https://<env>-objecttypen.<gemeente>.nl/api/v2/
+              api_type: orc
+              auth_type: api_key
+              header_key: Authorization
+              header_value: "Token REP_OBJECTTYPEN_OPENBEHEER_TOKEN_REP"   # 'Token ' prefix is required
+  ```
+
+Both are already in the chart `values.yaml` example blocks (objecttypen
+`tokenauth` and openbeheer `zgw_consumers`); this is the same matching trap as
+Open Archiefbeheer above — the token string must be identical on both ends.
+
+#### What IN-2345 fixed (do not repeat)
+
+- **Missing `Token ` prefix** on the Open Beheer `header_value` — it was just
+  `REP_..._REP`. Objecttypen rejects a header without `Token `.
+- **Mismatched secret name** — the two sides used different tokens
+  (`OPENBEHEER_CREDENTIALS_OBJECTTYPEN_TOKEN` vs `OBJECTTYPEN_OPENBEHEER_TOKEN`).
+  Standardise on **`OBJECTTYPEN_OPENBEHEER_TOKEN`** everywhere.
+
+#### Action required
+
+1. Provision the `objecttypen-openbeheer-token` secret in Key Vault and map it
+   to `OBJECTTYPEN_OPENBEHEER_TOKEN` in the pipeline `application.yml` **in the
+   shared/objecttypen section**, not only the openbeheer block — otherwise the
+   `objecttypen-config` Job cannot substitute it.
+2. **Only enable the objecttypen `openbeheer` tokenauth entry when Open Beheer
+   is enabled and the secret is provisioned.** The `objecttypen-config` Job
+   validates the token strictly and **fails on an unsubstituted `REP_..._REP`
+   placeholder** — keep the entry commented out while openbeheer is disabled.
+3. Configure both sides with the same secret and re-run the upgrade; confirm
+   Open Beheer can list object types (no 401/403 against the Objecttypen API).

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.7.6.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.7.6.md
@@ -1,0 +1,81 @@
+# Upgrade guide: PodiumD 4.7.5 → 4.7.6
+
+4.7.6 is a documentation/configuration-hardening patch. No image bumps.
+
+## Changes
+
+### Open Archiefbeheer `external_registers` — objecten-api + openklant-api matching
+
+4.7.6 completes the Open Archiefbeheer (OAB) `external_registers` example in
+`values.yaml` and fixes a typo in the OpenKlant `api_root` of several older
+upgrade guides (`opeklant` → `openklant`).
+
+OAB resolves each external register by an **exact** match between the
+identifiers under `external_registers.<register>.services_identifiers` and the
+`identifier` of a `zgw_consumers.services` entry. There is no fuzzy matching, so
+any mismatch silently breaks that register's link (the linked Open Klant /
+Objecten register does not work in OAB, with no error at config time).
+
+Two registers are wired in the example:
+
+- **objecten** → `objecten-api` (service `api_type: orc`, api_key auth).
+- **openklant** → `openklant-api` (service `api_type: kc`, api_key auth). In
+  **most** PodiumD environments this service was provisioned as `openklant-api`,
+  **not** `openklant-klantinteracties`. An example copied from elsewhere that
+  points at `openklant-klantinteracties` while the provisioned service is
+  `openklant-api` (or the reverse) cannot be resolved.
+
+Working example (the `services_identifiers` values must be **identical** to the
+`identifier` of the matching `zgw_consumers.services` entry):
+
+```yaml
+openarchiefbeheer:
+  configuration:
+    data: |-
+      zgw_consumers_config_enable: true
+      zgw_consumers:
+        services:
+        # ... other services ...
+        - identifier: objecten-api            # <-- referenced below
+          label: Objecten API
+          api_root: https://objecten.example.com/api/v2/
+          api_type: orc
+          auth_type: api_key
+          header_key: Authorization
+          header_value: "Token REP_OBJECTEN_CREDENTIALS_OPENARCHIEFBEHEER_TOKEN_REP"
+        - identifier: openklant-api           # <-- referenced below (NOT openklant-klantinteracties)
+          label: Klanten API
+          api_root: https://openklant.example.com/klantinteracties/api/v1/
+          api_type: kc
+          auth_type: api_key
+          header_key: Authorization
+          header_value: "Token REP_OPENKLANT_CREDENTIALS_OPENARCHIEFBEHEER_TOKEN_REP"
+
+      external_registers_enabled: true
+      external_registers:
+        openklant:
+          enabled: true
+          services_identifiers:
+          - openklant-api                     # must equal the service identifier above
+        objecten:
+          enabled: true
+          services_identifiers:
+          - objecten-api                      # must equal the service identifier above
+```
+
+#### Action required
+
+1. Find the identifiers of the Open Klant and Objecten services provisioned in
+   your environment (the `zgw_consumers.services[].identifier` values — commonly
+   `openklant-api` and `objecten-api`).
+2. Make every entry under `external_registers.*.services_identifiers` use
+   **those exact identifiers**.
+3. Re-run the `openarchiefbeheer-config` Job (`helm upgrade`) and confirm both
+   registers resolve.
+
+Do not assume the example values are correct — check the per-gemeente
+`podiumd.yml` against what is actually provisioned. This is the same trap first
+documented in [`upgrade-from-4.7.3-to-4.7.4.md`](upgrade-from-4.7.3-to-4.7.4.md);
+4.7.6 only corrects/completes the in-repo example. See
+[`openarchiefbeheer-known-issues.md`](openarchiefbeheer-known-issues.md) for
+other OAB configuration traps.

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1279,7 +1279,7 @@ openarchiefbeheer:
     #     # docs/upgrade-from-4.7.3-to-4.7.4.md.
     #     - identifier: openklant-api
     #       label: Klanten API
-    #       api_root: https://opeklant.example.com/klantinteracties/api/v1/
+    #       api_root: https://openklant.example.com/klantinteracties/api/v1/
     #       api_type: kc
     #       auth_type: api_key
     #       header_key: Authorization

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1110,6 +1110,11 @@ objecttypen:
     #         organization: Organization 1
     #         application: Application 1
     #         administration: Administration 1
+    #       # IN-2345: this token MUST equal the 'Token <...>' value in the
+    #       # openbeheer objecttypen-service header (same OBJECTTYPEN_OPENBEHEER_TOKEN
+    #       # secret on both sides). Only enable this entry when openbeheer is
+    #       # enabled AND the secret is provisioned — the objecttypen-config Job
+    #       # validates strictly and fails on an unsubstituted REP_..._REP placeholder.
     #       - identifier: openbeheer-token
     #         token: {value_from: {env: objecttypen_openbeheer_token}}
     #         contact_person: Open Beheer

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1564,15 +1564,8 @@ openklant:
     disabled: true
 
 openformulieren:
-  # override: values-enable-observability.yaml adds a settings.otel block to enable OTEL
-  # -- Outgoing/external HTTP request logging — disabled by default (since 4.7.4)
-  #    via the master switch LOG_OUTGOING_REQUESTS=False, which empties the
-  #    logging handlers (no emit AND no DB save). LOG_OUTGOING_REQUESTS_DB_SAVE is
-  #    left at its upstream default. The chart exposes no structured key, so this
-  #    is set via extraEnvVars. See docs/upgrade-from-4.7.3-to-4.7.4.md.
-  extraEnvVars:
-    - name: LOG_OUTGOING_REQUESTS
-      value: "False"
+  # revert: verwijder LOG_OUTGOING_REQUESTS override (defaults True)
+  # NAV verdere analyse is request logging wel gewenst !
   configuration:
     enabled: true
     job:


### PR DESCRIPTION
## Purpose
4.7.6 patch release — no image bumps. Contains one runtime-impactful change (Open Formulieren logging revert), plus documentation and comment-only fixes.

## Changes

### Runtime impact

**Open Formulieren — revert `LOG_OUTGOING_REQUESTS=False` (introduced in 4.7.4)**
Removes the `extraEnvVars` override, reverting to the upstream default (`True` — logging enabled). After upgrading, outgoing HTTP requests will be logged again. Operators who want to keep logging disabled must add the override in their per-gemeente `podiumd.yml` (see upgrade guide).

### Docs only (zero runtime impact)

- **New** `docs/upgrade-from-4.7.4-to-4.7.5.md` — documents the ZGW Office Add-in bump and ACR mirror rename (`add-in` → `addin`).
- **New** `docs/upgrade-from-4.7.5-to-4.7.6.md` — documents:
  - OAB `external_registers` exact-match requirement (services_identifiers must equal zgw_consumers service identifiers)
  - Open Beheer ↔ Objecttypen API token matching (IN-2345)
  - Open Formulieren request logging revert (see above)
- **`docs/UPGRADING.md`** — upgrade path extended to include the 4.7.5 and 4.7.6 hops.
- **Typo fix** `opeklant` → `openklant` in the OpenKlant `api_root` example in `values.yaml` and three older upgrade guides (`4.6.6→4.7.3`, `4.6.8→4.7.3`, `4.7.2→4.7.3`). All occurrences are inside commented-out example blocks.
- **`values.yaml` objecttypen** — added a warning comment inside the commented-out `openbeheer` tokenauth block (IN-2345). No runtime effect.

## Action required
Operators who want to keep outgoing request logging **disabled** for Open Formulieren must add to their per-gemeente `podiumd.yml`:
```yaml
openformulieren:
  extraEnvVars:
    - name: LOG_OUTGOING_REQUESTS
      value: "False"
```