### PR TITLE
PodiumD 4.8.0: bump OT redis-operator 0.24.0 -> 0.25.0

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -106,7 +106,7 @@ dependencies:
     condition: omc.enabled
   - name: redis-operator
     repository: "@opstree"
-    version: 0.24.0
+    version: 0.25.0
     condition: redis-operator.enabled
   - name: apisix
     version: 2.14.0

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -143,3 +143,12 @@
   url: docker.io/library/python
   version: "3.14-slim"
   digest: "sha256:8e4071294d046d45b31a902e02a8560a45c351898513b66ec659ca39fd30d170"
+
+# OT redis-operator (controller) — v0.24.0 -> v0.25.0
+# 0.25.0 includes PR #1720 (crash-loop fix on simultaneous RedisReplication
+# pod restart) and #1725 (persist sentinel.conf). The redis (v8.6.2) and
+# redis-exporter (v1.82.0) images are unchanged vs 4.7.3 and are omitted here.
+- name: redis-operator
+  url: quay.io/opstree/redis-operator
+  version: "v0.25.0"
+  digest: "sha256:d905da8b418228b100ead45965da835f3bed8c59fa069423a9a002b62942c940"

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -373,7 +373,7 @@ redis-operator:
     GenerateConfigInInitContainer: true
   redisOperator:
     imageName: quay.io/opstree/redis-operator
-    imageTag: "v0.24.0"
+    imageTag: "v0.25.0"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## What

Bump OT (opstree) redis-operator from **0.24.0 → 0.25.0**.

- `charts/podiumd/Chart.yaml`: dependency `redis-operator` `0.24.0` → `0.25.0` (`@opstree`)
- `charts/podiumd/values.yaml`: `redis-operator.redisOperator.imageTag` `v0.24.0` → `v0.25.0`

Vendored `charts/redis-operator-0.25.0.tgz` + `Chart.lock` are gitignored; CI regenerates them from `Chart.yaml`.

## Why

redis-operator **0.25.0** (released 2026-05-13) includes:
- **#1720** — prevent crash loop when all RedisReplication pods restart with empty `realMaster` (adds `Status.MasterNode` / `masterNodes[0]` fallback). Fixes #1403, #1144.
- **#1725** — persist `sentinel.conf` across container restarts.

## Scope notes

- **redis image unchanged** — `opstree/redis` stays `v8.6.2` (already the latest 8.6.x / 8.x tag; no patch available).
- **`labelMasterCronJob` workaround left enabled.** Its removal condition (*"a redis-operator release containing PR #1720"*) is now met by 0.25.0, but kept as a safety net. After validating a simultaneous redis-ha pod restart on a cluster (master labels reapplied, `redis-ha-master` Service keeps endpoints), it can be disabled via `redis-operator.redis-ha.labelMasterCronJob.enabled: false` in a follow-up.

## Validation

- `helm lint -f ci/lint-values.yaml`: no redis-operator findings (only pre-existing `zgw-office-addin` uri-format errors remain).
- `helm template`: renders `quay.io/opstree/redis-operator:v0.25.0`, redis `v8.6.2` unchanged, `redis-ha-label-master` CronJob still renders.

## Draft because

Pending in-cluster smoke test of the operator upgrade (simultaneous redis-ha pod restart) before marking ready.
