### PR TITLE
feature: PodiumD 4.8.0 update ZAC 5.0.1

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
       - contact
   - name: zaakafhandelcomponent
     alias: zac
-    version: 1.0.238 # ZAC 4.9.0 helm release
+    version: 1.0.250 # ZAC 5.0.0 helm release
     repository: "@zac"
     condition: zac.enabled
     tags:

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
       - contact
   - name: zaakafhandelcomponent
     alias: zac
-    version: 1.0.257 # ZAC 5.1.0 helm release
+    version: 1.0.251 # ZAC 5.0.1 helm release
     repository: "@zac"
     condition: zac.enabled
     tags:

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
       - contact
   - name: zaakafhandelcomponent
     alias: zac
-    version: 1.0.228 # ZAC 4.7.1 helm release
+    version: 1.0.238 # ZAC 4.9.0 helm release
     repository: "@zac"
     condition: zac.enabled
     tags:

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
       - contact
   - name: zaakafhandelcomponent
     alias: zac
-    version: 1.0.250 # ZAC 5.0.0 helm release
+    version: 1.0.251 # ZAC 5.0.1 helm release
     repository: "@zac"
     condition: zac.enabled
     tags:

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -82,7 +82,7 @@ dependencies:
       - zaak
   - name: zgw-office-addin
     repository: "@zgw-office-addin"
-    version: 0.0.88
+    version: 0.0.89
     condition: zgw-office-addin.enabled
   - name: internetaakafhandeling
     alias: ita

--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
       - contact
   - name: zaakafhandelcomponent
     alias: zac
-    version: 1.0.251 # ZAC 5.0.1 helm release
+    version: 1.0.257 # ZAC 5.1.0 helm release
     repository: "@zac"
     condition: zac.enabled
     tags:

--- a/charts/podiumd/docs/UPGRADING.md
+++ b/charts/podiumd/docs/UPGRADING.md
@@ -104,6 +104,7 @@ official path out of them:
 | [`upgrade-from-4.7.2-to-4.7.3.md`](upgrade-from-4.7.2-to-4.7.3.md) | Granular 4.7.x patch note (folded into the 4.6.8 → 4.7.3 guide). |
 | [`upgrade-from-4.7.3-to-4.8.0.md`](upgrade-from-4.7.3-to-4.8.0.md) | Alternate entry point for environments still on 4.7.3 (the official path enters 4.8.0 via 4.7.5). |
 | [`values-changes-4.7.0.md`](values-changes-4.7.0.md) | Full values add/change/remove table for the 4.7.0 jump. |
+| [`values-changes-4.8.0.md`](values-changes-4.8.0.md) | Full values add/change/remove table for the 4.8.0 jump (ZAC 5.0.1 breaking changes + ITA medewerker). |
 
 The 4.7.x granular notes are intentionally retained for now; once the 4.7 line
 closes they can be retired in favour of the consolidated 4.6.8 → 4.7.3 guide.

--- a/charts/podiumd/docs/UPGRADING.md
+++ b/charts/podiumd/docs/UPGRADING.md
@@ -105,6 +105,7 @@ official path out of them:
 | [`upgrade-from-4.7.3-to-4.8.0.md`](upgrade-from-4.7.3-to-4.8.0.md) | Alternate entry point for environments still on 4.7.3 (the official path enters 4.8.0 via 4.7.5). |
 | [`values-changes-4.7.0.md`](values-changes-4.7.0.md) | Full values add/change/remove table for the 4.7.0 jump. |
 | [`values-changes-4.8.0.md`](values-changes-4.8.0.md) | Full values add/change/remove table for the 4.8.0 jump (ZAC 5.0.1 breaking changes + ITA medewerker). |
+| [`zac-brp-protocollering.md`](zac-brp-protocollering.md) | ZAC BRP protocollering vendor reference (iConnect, eServices, 2Secure/EnableU) — ZAC 5.0.1. |
 
 The 4.7.x granular notes are intentionally retained for now; once the 4.7 line
 closes they can be retired in favour of the consolidated 4.6.8 → 4.7.3 guide.

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -1,23 +1,31 @@
 # Images new or changed in podiumd 4.8.0 vs 4.7.3.
 #
-# Single change: Open Inwoner Platform (OIP) 2.1.2 -> 2.3.0.
-#   * Helm chart openinwoner 2.1.3 -> 2.2.0 (appVersion 2.3.0).
-#   * Image tag pin in charts/podiumd/values.yaml: openinwoner.image.tag
-#     "2.1.2" -> "2.3.0".
-# Spans two upstream releases:
-#   - 2.2.0 (2026-04-20): Django CMS v3 -> v4 (one-time `cms4_migration`,
-#     run by the chart's cms4MigrationInitContainer), Elasticsearch HTTP
-#     basic auth, BRP_VERSION env -> admin-configurable field (auto-migrated).
-#   - 2.3.0 (2026-05-29): ClamAV virus scanning of uploads (opt-in),
-#     ZGW cache-warmup timeouts + dedicated low-latency Celery worker.
+# Changes in this release:
+#   1. Open Inwoner Platform (OIP) 2.1.2 -> 2.3.0.
+#      * Helm chart openinwoner 2.1.3 -> 2.2.0 (appVersion 2.3.0).
+#      * Image tag pin in charts/podiumd/values.yaml: openinwoner.image.tag
+#        "2.1.2" -> "2.3.0".
+#      Spans two upstream releases:
+#        - 2.2.0 (2026-04-20): Django CMS v3 -> v4 (one-time `cms4_migration`,
+#          run by the chart's cms4MigrationInitContainer), Elasticsearch HTTP
+#          basic auth, BRP_VERSION env -> admin-configurable field (auto-migrated).
+#        - 2.3.0 (2026-05-29): ClamAV virus scanning of uploads (opt-in),
+#          ZGW cache-warmup timeouts + dedicated low-latency Celery worker.
+#   2. ZAC (zaakafhandelcomponent) 4.7.2 -> 5.0.1 (major version bump).
+#      * Helm chart zaakafhandelcomponent 1.0.228 -> 1.0.251.
+#      * Breaking API changes: featureFlags.pabcIntegration removed;
+#        brpApi.apiKey changed from string to {header, value} object.
+#      * Sub-image bumps: nginx-unprivileged 1.30.2->1.31.1, gotenberg
+#        8.31.0->8.33.0, OPA 1.15.2-static->1.17.1-static,
+#        busybox 1.37.0-glibc->1.38.0-glibc.
+#   3. Renovate-integrated bumps: nginx-unprivileged 1.30.2 digest refresh,
+#      alpine/k8s 1.34.7->1.36.2, keycloak-config-cli 6.5.0-26->6.5.1-26.
+#
 # See docs/upgrade-from-4.7.3-to-4.8.0.md for the operator upgrade notes.
 #
-# Mirror name is `openinwoner` (no hyphen), not `open-inwoner`; see
-# docs/images/acr-mirror-naming.md for the upstream->ACR mapping.
-# Digest below is the single linux/amd64 manifest published on Docker Hub,
-# verified live against registry-1.docker.io (Docker-Content-Digest).
-# The nginx sidecar stays on nginx-unprivileged 1.30.2; the pinned digest
-# was refreshed (see the Renovate-integration section at the end of this file).
+# Mirror names: `openinwoner` (no hyphen), `zac` (renamed from
+# zaakafhandelcomponent), `nginx-unprivileged` (keeps hyphen), `gotenberg`,
+# `opa`, `busybox`. See docs/images/acr-mirror-naming.md.
 
 # Open Inwoner Platform (OIP) — 2.1.2 -> 2.3.0
 - name: openinwoner
@@ -46,12 +54,44 @@
   version: "3.2.0"
   digest: "sha256:eee4567fd5bfaa7eb2ec13fa1a34cfabb402939ffdc79de8159f5dc00754bafb"
 
+# ZAC — 4.7.2 -> 5.0.1
+- name: zac
+  url: ghcr.io/infonl/zaakafhandelcomponent
+  version: "5.0.1"
+  digest: "sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659"
+
+# ZAC - nginx-unprivileged — 1.30.2 -> 1.31.1 (ZAC nginx sidecar only;
+# other components remain on 1.30.2 — see digest-refresh entry below)
+- name: nginx-unprivileged
+  url: docker.io/nginxinc/nginx-unprivileged
+  version: "1.31.1"
+  digest: "sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
+
+# ZAC - Gotenberg (office converter) — 8.31.0 -> 8.33.0
+- name: gotenberg
+  url: docker.io/gotenberg/gotenberg
+  version: "8.33.0"
+  digest: "sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8"
+
+# ZAC - Open Policy Agent — 1.15.2-static -> 1.17.1-static
+- name: opa
+  url: docker.io/openpolicyagent/opa
+  version: "1.17.1-static"
+  digest: "sha256:c29f8ee8dbe66608a1c04e9be84b04efc46877625e6b0877e559954565209efc"
+
+# ZAC - busybox (Solr init container) — 1.37.0-glibc -> 1.38.0-glibc
+- name: busybox
+  url: docker.io/library/busybox
+  version: "1.38.0-glibc"
+  digest: "sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a"
+
 # Renovate dependency bumps integrated into 4.8.0 (PRs #292, #324, #334).
 # Digests verified live against the source registry (Docker-Content-Digest).
 # PR #294 (azure/k8s-bake v3 -> v4) is a GitHub Action, not a container image,
 # so it is not listed here.
 
 # nginx-unprivileged — 1.30.2 digest refresh (PR #334): 77fb538 -> 1d13071
+# (used by all components other than the ZAC nginx sidecar)
 - name: nginx-unprivileged
   url: docker.io/nginxinc/nginx-unprivileged
   version: "1.30.2"

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -18,8 +18,8 @@
 #      * Sub-image bumps: nginx-unprivileged 1.30.2->1.31.1, gotenberg
 #        8.31.0->8.33.0, OPA 1.15.2-static->1.17.1-static,
 #        busybox 1.37.0-glibc->1.38.0-glibc.
-#   3. Renovate-integrated bumps: nginx-unprivileged 1.30.2 digest refresh,
-#      alpine/k8s 1.34.7->1.36.2, keycloak-config-cli 6.5.0-26->6.5.1-26.
+#   3. Renovate-integrated bumps: alpine/k8s 1.34.7->1.36.2,
+#      keycloak-config-cli 6.5.0-26->6.5.1-26.
 #
 # See docs/upgrade-from-4.7.3-to-4.8.0.md for the operator upgrade notes.
 #
@@ -60,8 +60,7 @@
   version: "5.0.1"
   digest: "sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659"
 
-# ZAC - nginx-unprivileged — 1.30.2 -> 1.31.1 (ZAC nginx sidecar only;
-# other components remain on 1.30.2 — see digest-refresh entry below)
+# nginx-unprivileged — 1.30.2 -> 1.31.1 (all components)
 - name: nginx-unprivileged
   url: docker.io/nginxinc/nginx-unprivileged
   version: "1.31.1"
@@ -85,17 +84,10 @@
   version: "1.38.0-glibc"
   digest: "sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a"
 
-# Renovate dependency bumps integrated into 4.8.0 (PRs #292, #324, #334).
+# Renovate dependency bumps integrated into 4.8.0 (PRs #292, #324).
 # Digests verified live against the source registry (Docker-Content-Digest).
 # PR #294 (azure/k8s-bake v3 -> v4) is a GitHub Action, not a container image,
 # so it is not listed here.
-
-# nginx-unprivileged — 1.30.2 digest refresh (PR #334): 77fb538 -> 1d13071
-# (used by all components other than the ZAC nginx sidecar)
-- name: nginx-unprivileged
-  url: docker.io/nginxinc/nginx-unprivileged
-  version: "1.30.2"
-  digest: "sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
 
 # alpine/k8s (redis-ha label-master job) — 1.34.7 -> 1.36.2 (PR #292)
 - name: k8s

--- a/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
@@ -167,7 +167,7 @@ to 5.0.1, a major-version jump.
 - Helm chart `zaakafhandelcomponent` `1.0.228` → `1.0.251` (appVersion
   `5.0.1`) in `charts/podiumd/Chart.yaml`.
 - Sub-image bumps in `charts/podiumd/values.yaml`:
-  - `zac.nginx.image.tag` `1.30.2` → `1.31.1`
+  - `zac.nginx.image.tag` and all other `nginx-unprivileged` pins `1.30.2` → `1.31.1`
   - `zac.office_converter.image.tag` `8.31.0` → `8.33.0` (Gotenberg)
   - `zac.opa.image.tag` `1.15.2-static` → `1.17.1-static` (Open Policy Agent)
   - `zac.solr.busyBoxImage.tag` `1.37.0-glibc` → `1.38.0-glibc`

--- a/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
@@ -236,6 +236,20 @@ vendor-specific configuration from
 If protocollering was disabled (`aanbieder: ""`), set `enabled: false` and
 remove the old keys — no further action is needed.
 
+**Additional action required for iConnect environments:** disable the
+`apiproxy.brp.toepassingHeaderName` injection — ZAC 5.0.1 now sends the
+toepassing header directly via protocollering, so the api-proxy should no
+longer own this header. Set `toepassingHeaderName: ""` in your gemeente file:
+
+```yaml
+apiproxy:
+  locations:
+    brp:
+      toepassingHeaderName: ""
+```
+
+See [`docs/zac-brp-protocollering.md`](zac-brp-protocollering.md) for details.
+
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 
 Open Beheer authenticates to the **Objecttypen API** with an API token.

--- a/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
@@ -13,6 +13,7 @@
 | ITA (.web, .poller) | 3.2.0 | 3.2.0 | **action required** |
 | brp-personen-mock   | 2.7.0-202606230850 | 1.2.9 | no action required |
 | zaakbrug            | 1.26.14 | 2.3.27 | no action required |
+| ZAC                 | 5.0.1 | 1.0.251 | **action required** |
 
 
 ## Changes
@@ -157,6 +158,56 @@ ita:
     type: "https://<env>-objecttypen.<gemeente>.nl/api/v2/objecttypes/REP_CONTACT_MEDEWERKER_UUID_REP"
     typeVersion: 1    
 ```
+
+### ZAC 4.7.2 → 5.0.1
+
+PodiumD 4.8.0 (info.nl) bumps the **Zaakafhandelcomponent (ZAC)** from 4.7.2
+to 5.0.1, a major-version jump.
+
+- Helm chart `zaakafhandelcomponent` `1.0.228` → `1.0.251` (appVersion
+  `5.0.1`) in `charts/podiumd/Chart.yaml`.
+- Sub-image bumps in `charts/podiumd/values.yaml`:
+  - `zac.nginx.image.tag` `1.30.2` → `1.31.1`
+  - `zac.office_converter.image.tag` `8.31.0` → `8.33.0` (Gotenberg)
+  - `zac.opa.image.tag` `1.15.2-static` → `1.17.1-static` (Open Policy Agent)
+  - `zac.solr.busyBoxImage.tag` `1.37.0-glibc` → `1.38.0-glibc`
+
+#### Breaking change: `brpApi.apiKey` restructured
+
+`zac.brpApi.apiKey` changed from a plain string to an object with `header`
+and `value` fields.
+
+**Action required:** if your gemeente `podiumd.yml` overrides
+`zac.brpApi.apiKey`, replace the string form:
+
+```yaml
+# before (4.7.x)
+zac:
+  brpApi:
+    apiKey: "your-api-key"
+```
+
+with the new object form:
+
+```yaml
+# after (5.0.1)
+zac:
+  brpApi:
+    apiKey:
+      header: "x-api-key"
+      value: "your-api-key"
+```
+
+If `zac.brpApi.apiKey` is not overridden in your gemeente file, no action
+is required — the chart default already uses the new structure.
+
+#### Breaking change: `featureFlags.pabcIntegration` removed
+
+The `zac.featureFlags.pabcIntegration` key was removed in ZAC 5.x.
+
+**Action required:** if your gemeente `podiumd.yml` sets
+`zac.featureFlags.pabcIntegration: true` or `false`, remove that line. The
+PABC integration is now controlled separately (see PABC chart values).
 
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 

--- a/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.3-to-4.8.0.md
@@ -209,6 +209,33 @@ The `zac.featureFlags.pabcIntegration` key was removed in ZAC 5.x.
 `zac.featureFlags.pabcIntegration: true` or `false`, remove that line. The
 PABC integration is now controlled separately (see PABC chart values).
 
+#### Breaking change: `protocollering` restructured
+
+The BRP protocollering block was completely redesigned in ZAC 5.0.1. The
+single `aanbieder` selector and implicit vendor defaults are replaced by an
+explicit, field-per-dimension structure.
+
+**Key renames and removals:**
+
+| Old key (4.7.x) | New key (5.0.1) |
+|---|---|
+| `protocollering.aanbieder: "iConnect"` | `protocollering.enabled: true` + explicit fields |
+| `protocollering.aanbieder: ""` | `protocollering.enabled: false` |
+| `protocollering.verwerkingsregister` | `protocollering.verwerking.register` |
+
+**New fields with no 4.7.x equivalent:** `logLevel` (at `brpApi` level),
+`protocollering.systemUser`, `protocollering.originOin`, `protocollering.doelbinding.perZaaktype`,
+`protocollering.doelbinding.header`, `protocollering.verwerking.header`,
+`protocollering.gebruiker`, `protocollering.toepassing`.
+
+**Action required:** if your gemeente `podiumd.yml` overrides any
+`zac.brpApi.protocollering.*` keys, replace the old block with the
+vendor-specific configuration from
+[`docs/zac-brp-protocollering.md`](zac-brp-protocollering.md).
+
+If protocollering was disabled (`aanbieder: ""`), set `enabled: false` and
+remove the old keys — no further action is needed.
+
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 
 Open Beheer authenticates to the **Objecttypen API** with an API token.

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
@@ -261,6 +261,20 @@ vendor-specific configuration from
 If protocollering was disabled (`aanbieder: ""`), set `enabled: false` and
 remove the old keys — no further action is needed.
 
+**Additional action required for iConnect environments:** disable the
+`apiproxy.brp.toepassingHeaderName` injection — ZAC 5.0.1 now sends the
+toepassing header directly via protocollering, so the api-proxy should no
+longer own this header. Set `toepassingHeaderName: ""` in your gemeente file:
+
+```yaml
+apiproxy:
+  locations:
+    brp:
+      toepassingHeaderName: ""
+```
+
+See [`docs/zac-brp-protocollering.md`](zac-brp-protocollering.md) for details.
+
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 
 Open Beheer authenticates to the **Objecttypen API** with an API token.

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
@@ -192,7 +192,7 @@ to 5.0.1, a major-version jump.
 - Helm chart `zaakafhandelcomponent` `1.0.228` → `1.0.251` (appVersion
   `5.0.1`) in `charts/podiumd/Chart.yaml`.
 - Sub-image bumps in `charts/podiumd/values.yaml`:
-  - `zac.nginx.image.tag` `1.30.2` → `1.31.1`
+  - `zac.nginx.image.tag` and all other `nginx-unprivileged` pins `1.30.2` → `1.31.1`
   - `zac.office_converter.image.tag` `8.31.0` → `8.33.0` (Gotenberg)
   - `zac.opa.image.tag` `1.15.2-static` → `1.17.1-static` (Open Policy Agent)
   - `zac.solr.busyBoxImage.tag` `1.37.0-glibc` → `1.38.0-glibc`

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
@@ -234,6 +234,33 @@ The `zac.featureFlags.pabcIntegration` key was removed in ZAC 5.x.
 `zac.featureFlags.pabcIntegration: true` or `false`, remove that line. The
 PABC integration is now controlled separately (see PABC chart values).
 
+#### Breaking change: `protocollering` restructured
+
+The BRP protocollering block was completely redesigned in ZAC 5.0.1. The
+single `aanbieder` selector and implicit vendor defaults are replaced by an
+explicit, field-per-dimension structure.
+
+**Key renames and removals:**
+
+| Old key (4.7.x) | New key (5.0.1) |
+|---|---|
+| `protocollering.aanbieder: "iConnect"` | `protocollering.enabled: true` + explicit fields |
+| `protocollering.aanbieder: ""` | `protocollering.enabled: false` |
+| `protocollering.verwerkingsregister` | `protocollering.verwerking.register` |
+
+**New fields with no 4.7.x equivalent:** `logLevel` (at `brpApi` level),
+`protocollering.systemUser`, `protocollering.originOin`, `protocollering.doelbinding.perZaaktype`,
+`protocollering.doelbinding.header`, `protocollering.verwerking.header`,
+`protocollering.gebruiker`, `protocollering.toepassing`.
+
+**Action required:** if your gemeente `podiumd.yml` overrides any
+`zac.brpApi.protocollering.*` keys, replace the old block with the
+vendor-specific configuration from
+[`docs/zac-brp-protocollering.md`](zac-brp-protocollering.md).
+
+If protocollering was disabled (`aanbieder: ""`), set `enabled: false` and
+remove the old keys — no further action is needed.
+
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 
 Open Beheer authenticates to the **Objecttypen API** with an API token.

--- a/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.5-to-4.8.0.md
@@ -34,6 +34,7 @@ identical.
 | ITA (.web, .poller) | 3.2.0 | 3.2.0 | **action required** |
 | brp-personen-mock   | 2.7.0-202606230850 | 1.2.9 | no action required |
 | zaakbrug            | 1.26.14 | 2.3.27 | no action required |
+| ZAC                 | 5.0.1 | 1.0.251 | **action required** |
 
 > A separate test overlay (`feature/podiumd-4.8.0-ontw-mayk-test-updates`, PR
 > #340) pins newer Maykin/upstream images on top of 4.8.0 for the *ontwikkel*
@@ -182,6 +183,56 @@ ita:
     type: "https://<env>-objecttypen.<gemeente>.nl/api/v2/objecttypes/REP_CONTACT_MEDEWERKER_UUID_REP"
     typeVersion: 1    
 ```
+
+### ZAC 4.7.2 → 5.0.1
+
+PodiumD 4.8.0 (info.nl) bumps the **Zaakafhandelcomponent (ZAC)** from 4.7.2
+to 5.0.1, a major-version jump.
+
+- Helm chart `zaakafhandelcomponent` `1.0.228` → `1.0.251` (appVersion
+  `5.0.1`) in `charts/podiumd/Chart.yaml`.
+- Sub-image bumps in `charts/podiumd/values.yaml`:
+  - `zac.nginx.image.tag` `1.30.2` → `1.31.1`
+  - `zac.office_converter.image.tag` `8.31.0` → `8.33.0` (Gotenberg)
+  - `zac.opa.image.tag` `1.15.2-static` → `1.17.1-static` (Open Policy Agent)
+  - `zac.solr.busyBoxImage.tag` `1.37.0-glibc` → `1.38.0-glibc`
+
+#### Breaking change: `brpApi.apiKey` restructured
+
+`zac.brpApi.apiKey` changed from a plain string to an object with `header`
+and `value` fields.
+
+**Action required:** if your gemeente `podiumd.yml` overrides
+`zac.brpApi.apiKey`, replace the string form:
+
+```yaml
+# before (4.7.x)
+zac:
+  brpApi:
+    apiKey: "your-api-key"
+```
+
+with the new object form:
+
+```yaml
+# after (5.0.1)
+zac:
+  brpApi:
+    apiKey:
+      header: "x-api-key"
+      value: "your-api-key"
+```
+
+If `zac.brpApi.apiKey` is not overridden in your gemeente file, no action
+is required — the chart default already uses the new structure.
+
+#### Breaking change: `featureFlags.pabcIntegration` removed
+
+The `zac.featureFlags.pabcIntegration` key was removed in ZAC 5.x.
+
+**Action required:** if your gemeente `podiumd.yml` sets
+`zac.featureFlags.pabcIntegration: true` or `false`, remove that line. The
+PABC integration is now controlled separately (see PABC chart values).
 
 ### Open Beheer ↔ Objecttypen API token (IN-2345)
 

--- a/charts/podiumd/docs/values-changes-4.8.0.md
+++ b/charts/podiumd/docs/values-changes-4.8.0.md
@@ -7,7 +7,8 @@ Companion to (upgrade-from-4.6.5-to-4.7.0.md). This file lists every value overr
 | Component | Required action | Type |
 |-----------|----------------|------|
 | `ita.medewerker` | New required block | Required if ITA enabled |
-|  |  |  |
+| `zac.brpApi.apiKey` | String → object (`{header, value}`) | Required if ZAC enabled and key overridden |
+| `zac.featureFlags.pabcIntegration` | Remove this key | Required if present in gemeente file |
 
 ## Required changes
 
@@ -21,17 +22,57 @@ ita:
     typeVersion: 1    
 ```
 
+### 2. ZAC `brpApi.apiKey` — string to object (ZAC 5.0.1)
+
+ZAC 5.x changed `brpApi.apiKey` from a plain string to a structured object.
+If your gemeente file overrides this value, update it:
+
+```yaml
+# before (4.7.x)
+zac:
+  brpApi:
+    apiKey: "your-api-key"
+
+# after (5.0.1)
+zac:
+  brpApi:
+    apiKey:
+      header: "x-api-key"
+      value: "your-api-key"
+```
+
+If the key is **not** overridden in your gemeente file, no action is needed —
+the chart default already has the new structure.
+
+### 3. ZAC `featureFlags.pabcIntegration` — removed (ZAC 5.0.1)
+
+ZAC 5.x removed this feature flag entirely. If your gemeente file contains:
+
+```yaml
+zac:
+  featureFlags:
+    pabcIntegration: true   # or false
+```
+
+remove the entire `featureFlags.pabcIntegration` key (and `featureFlags:`
+block if it becomes empty). Leaving it in place causes a Helm validation
+error on deploy.
+
 ## New optional fields
 
 
 
 ## Cleanup — image tag overrides
 
-The chart `values.yaml` already pins the new versions. Remove explicit tag overrides in gemeente files when they merely repeated a 4.6.x value, otherwise bump to:
+The chart `values.yaml` already pins the new versions. Remove explicit tag overrides in gemeente files when they merely repeated a 4.7.x value, otherwise bump to:
 
 | Component | New default tag |
 |-----------|----------------|
-|  |  |
+| `zac.image.tag` | `5.0.1@sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659` |
+| `zac.nginx.image.tag` | `1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61` |
+| `zac.office_converter.image.tag` | `8.33.0@sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8` |
+| `zac.opa.image.tag` | `1.17.1-static@sha256:c29f8ee8dbe66608a1c04e9be84b04efc46877625e6b0877e559954565209efc` |
+| `zac.solr.busyBoxImage.tag` | `1.38.0-glibc@sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a` |
 
 
 ## Pre-deploy checklist

--- a/charts/podiumd/docs/values-changes-4.8.0.md
+++ b/charts/podiumd/docs/values-changes-4.8.0.md
@@ -11,6 +11,7 @@ Companion to (upgrade-from-4.6.5-to-4.7.0.md). This file lists every value overr
 | `zac.featureFlags.pabcIntegration` | Remove this key | Required if present in gemeente file |
 | `zac.brpApi.protocollering` | Full restructure — see below | Required if protocollering was configured |
 | `zac.brpApi.logLevel` | New field (default `"OFF"`) | Optional |
+| `apiproxy.locations.brp.toepassingHeaderName` | Set to `""` — ZAC now owns this header via protocollering | Required for iConnect |
 
 ## Required changes
 

--- a/charts/podiumd/docs/values-changes-4.8.0.md
+++ b/charts/podiumd/docs/values-changes-4.8.0.md
@@ -69,7 +69,7 @@ The chart `values.yaml` already pins the new versions. Remove explicit tag overr
 | Component | New default tag |
 |-----------|----------------|
 | `zac.image.tag` | `5.0.1@sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659` |
-| `zac.nginx.image.tag` | `1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61` |
+| `*.nginx.image.tag` (all components) | `1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61` |
 | `zac.office_converter.image.tag` | `8.33.0@sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8` |
 | `zac.opa.image.tag` | `1.17.1-static@sha256:c29f8ee8dbe66608a1c04e9be84b04efc46877625e6b0877e559954565209efc` |
 | `zac.solr.busyBoxImage.tag` | `1.38.0-glibc@sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a` |

--- a/charts/podiumd/docs/values-changes-4.8.0.md
+++ b/charts/podiumd/docs/values-changes-4.8.0.md
@@ -9,6 +9,8 @@ Companion to (upgrade-from-4.6.5-to-4.7.0.md). This file lists every value overr
 | `ita.medewerker` | New required block | Required if ITA enabled |
 | `zac.brpApi.apiKey` | String → object (`{header, value}`) | Required if ZAC enabled and key overridden |
 | `zac.featureFlags.pabcIntegration` | Remove this key | Required if present in gemeente file |
+| `zac.brpApi.protocollering` | Full restructure — see below | Required if protocollering was configured |
+| `zac.brpApi.logLevel` | New field (default `"OFF"`) | Optional |
 
 ## Required changes
 
@@ -57,6 +59,36 @@ zac:
 remove the entire `featureFlags.pabcIntegration` key (and `featureFlags:`
 block if it becomes empty). Leaving it in place causes a Helm validation
 error on deploy.
+
+### 4. ZAC `brpApi.protocollering` — restructured (ZAC 5.0.1)
+
+The entire protocollering block was redesigned. The `aanbieder` selector is
+removed; each protocol dimension now has explicit header/value fields.
+
+**Removed keys:**
+
+| Key | Action |
+|---|---|
+| `zac.brpApi.protocollering.aanbieder` | Remove; replaced by `enabled` + explicit fields |
+| `zac.brpApi.protocollering.verwerkingsregister` | Rename to `protocollering.verwerking.register` |
+
+**New keys:** `zac.brpApi.logLevel`, `protocollering.enabled`,
+`protocollering.systemUser`, `protocollering.originOin.{oin,header}`,
+`protocollering.doelbinding.{perZaaktype,header}`,
+`protocollering.verwerking.header`, `protocollering.gebruiker.header`,
+`protocollering.toepassing.{header,value}`.
+
+For full vendor-specific YAML blocks (iConnect, eServices, 2Secure/EnableU)
+see [`docs/zac-brp-protocollering.md`](zac-brp-protocollering.md).
+
+If protocollering was off (`aanbieder: ""`), replace with:
+
+```yaml
+zac:
+  brpApi:
+    protocollering:
+      enabled: false
+```
 
 ## New optional fields
 

--- a/charts/podiumd/docs/zac-brp-protocollering.md
+++ b/charts/podiumd/docs/zac-brp-protocollering.md
@@ -102,13 +102,49 @@ zac:
 
 ---
 
+## API-proxy: disable `toepassingHeaderName` when protocollering is enabled
+
+The `apiproxy` component has a `brp.toepassingHeaderName` setting that
+controls the toepassing header forwarded to the BRP gateway. When set, the
+api-proxy uses a pass-through-with-fallback pattern (nginx `map`): it forwards
+the header value if one is sent, or injects `toepassingDefaultValue` if
+is is not.
+
+With ZAC 5.0.1 protocollering enabled, ZAC sends the toepassing header
+directly and the api-proxy will forward ZAC's value. However, to keep the
+configuration explicit and avoid any ambiguity about which component is
+responsible for the header, **disable the api-proxy injection** by setting
+`toepassingHeaderName` to `""`:
+
+```yaml
+# 4.7.x iConnect config — toepassingHeaderName was used as a fallback/injector
+apiproxy:
+  locations:
+    brp:
+      toepassingHeaderName: "X-Toepassing"
+      toepassingDefaultValue: "ZAC"
+
+# 5.0.1 — ZAC owns the header via protocollering; disable api-proxy injection
+apiproxy:
+  locations:
+    brp:
+      toepassingHeaderName: ""
+```
+
+When `toepassingHeaderName` is `""`, the nginx `map` and `proxy_set_header`
+blocks are not rendered at all. ZAC's `x-toepassing` header passes through to
+the BRP gateway via nginx's default header forwarding.
+
+For eServices and 2Secure environments `toepassingHeaderName` is typically
+already `""`, so no change is needed.
+
 ## Field reference
 
 | Field | Required | Description |
 |---|---|---|
 | `brpApi.logLevel` | no | Log level for BRP API calls. `"OFF"` suppresses request/response logging. |
 | `protocollering.enabled` | yes | Enable or disable BRP protocollering. |
-| `protocollering.systemUser` | iConnect, 2Secure | Fixed username sent as the acting system user. Omit for eServices. |
+| `protocollering.systemUser` | yes | Fixed username sent as the acting system user. |
 | `protocollering.originOin.oin` | when enabled | The gemeente's OIN, sent to identify the requesting organisation. |
 | `protocollering.originOin.header` | when enabled | HTTP header name for the OIN. |
 | `protocollering.doelbinding.perZaaktype` | yes | When `true`, ZAC derives the doelbinding from the zaaktype. When `false`, a fixed doelbinding header is sent (or omitted if `header` is empty). |

--- a/charts/podiumd/docs/zac-brp-protocollering.md
+++ b/charts/podiumd/docs/zac-brp-protocollering.md
@@ -1,0 +1,136 @@
+# ZAC — BRP protocollering configuration
+
+ZAC 5.0.1 replaced the single `protocollering.aanbieder` selector with an
+explicit, field-per-dimension structure. Each gemeente configures the exact
+HTTP headers and values their BRP gateway vendor expects, rather than ZAC
+inferring them from a vendor name.
+
+Protocollering is **disabled by default** (`protocollering.enabled: false`).
+Enable it only when the BRP gateway requires it.
+
+All values below go in the gemeente's `podiumd.yml` under `zac.brpApi`.
+
+---
+
+## iConnect
+
+```yaml
+zac:
+  brpApi:
+    url: http://api-proxy.podiumd.svc.cluster.local/brp
+    apiKey:
+      header: "x-api-key"
+      value: "geldige-brp-api-key"
+    logLevel: "OFF"
+    protocollering:
+      enabled: true
+      systemUser: "SystemUser"
+      originOin:
+        oin: "gemeentelijke OIN"
+        header: "x-origin-oin"
+      doelbinding:
+        perZaaktype: true
+        header: "x-doelbinding"
+        zoekmet: "BRPACT-ZoekenAlgemeen"
+        raadpleegmet: "BRPACT-ZacPersoonBasis"
+      verwerking:
+        header: "x-verwerking"
+        register: "DigitaleDienstverlening"
+      gebruiker:
+        header: "x-gebruiker"
+      toepassing:
+        header: "x-toepassing"
+        value: "dummy"
+```
+
+---
+
+## eServices
+
+```yaml
+zac:
+  brpApi:
+    url: http://api-proxy.podiumd.svc.cluster.local/brp
+    apiKey:
+      header: "x-api-key"
+      value: "dummy"
+    logLevel: "OFF"
+    protocollering:
+      enabled: true
+      originOin:
+        oin: "gemeentelijke OIN"
+        header: "x-request-organization"
+      doelbinding:
+        perZaaktype: false
+        header: ""
+      verwerking:
+        header: "x-request-afnemerscode"
+        register: "dummy"
+      gebruiker:
+        header: "x-request-user"
+      toepassing:
+        header: "x-request-application"
+        value: "dummy"
+```
+
+---
+
+## 2Secure / EnableU
+
+```yaml
+zac:
+  brpApi:
+    url: http://api-proxy.podiumd.svc.cluster.local/brp
+    apiKey:
+      header: "x-api-key"
+      value: "dummy"
+    logLevel: "OFF"
+    protocollering:
+      enabled: true
+      systemUser: "SystemUser"
+      doelbinding:
+        perZaaktype: false
+      verwerking:
+        header: "x-verwerking"
+        register: "dummy"
+      gebruiker:
+        header: "x-gebruiker"
+      toepassing:
+        header: "x-applicatie"
+        value: "dummy"
+```
+
+---
+
+## Field reference
+
+| Field | Required | Description |
+|---|---|---|
+| `brpApi.logLevel` | no | Log level for BRP API calls. `"OFF"` suppresses request/response logging. |
+| `protocollering.enabled` | yes | Enable or disable BRP protocollering. |
+| `protocollering.systemUser` | iConnect, 2Secure | Fixed username sent as the acting system user. Omit for eServices. |
+| `protocollering.originOin.oin` | when enabled | The gemeente's OIN, sent to identify the requesting organisation. |
+| `protocollering.originOin.header` | when enabled | HTTP header name for the OIN. |
+| `protocollering.doelbinding.perZaaktype` | yes | When `true`, ZAC derives the doelbinding from the zaaktype. When `false`, a fixed doelbinding header is sent (or omitted if `header` is empty). |
+| `protocollering.doelbinding.header` | when `perZaaktype: true` | HTTP header name for the doelbinding value. Set to `""` to omit the header. |
+| `protocollering.doelbinding.zoekmet` | iConnect | BRP action code for search operations. |
+| `protocollering.doelbinding.raadpleegmet` | iConnect | BRP action code for retrieval operations. |
+| `protocollering.verwerking.header` | when enabled | HTTP header name for the verwerking (processing) identifier. |
+| `protocollering.verwerking.register` | when enabled | Name of the verwerkingsregister (processing register). |
+| `protocollering.gebruiker.header` | when enabled | HTTP header name for the acting end-user. ZAC fills this with the logged-in user. |
+| `protocollering.toepassing.header` | when enabled | HTTP header name for the application identifier. |
+| `protocollering.toepassing.value` | when enabled | Fixed application identifier value sent in the header. |
+
+## Migration from ZAC 4.7.x
+
+The old `protocollering.aanbieder` field and implicit vendor-specific defaults
+are gone in ZAC 5.0.1. Map your previous configuration as follows:
+
+| Old (4.7.x) | New (5.0.1) |
+|---|---|
+| `protocollering.aanbieder: "iConnect"` | `protocollering.enabled: true` + full iConnect block above |
+| `protocollering.aanbieder: "2Secure"` | `protocollering.enabled: true` + full 2Secure block above |
+| `protocollering.aanbieder: ""` | `protocollering.enabled: false` |
+| `protocollering.verwerkingsregister: "..."` | `protocollering.verwerking.register: "..."` |
+| `protocollering.doelbinding.zoekmet` | `protocollering.doelbinding.zoekmet` (unchanged) |
+| `protocollering.doelbinding.raadpleegmet` | `protocollering.doelbinding.raadpleegmet` (unchanged) |

--- a/charts/podiumd/templates/redis-ha.yaml
+++ b/charts/podiumd/templates/redis-ha.yaml
@@ -22,6 +22,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "podiumd.labels" . | nindent 4 }}
+    {{- with $redisHa.serviceName }}
+    app: {{ . }}
+    service_name: {{ . }}
+    {{- end }}
 spec:
   clusterSize: {{ $redisHa.replicaCount }}
   kubernetesConfig:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2694,7 +2694,7 @@ zac:
   image:
     #repository: ghcr.io/infonl/zaakafhandelcomponent
     pullPolicy: IfNotPresent
-    tag: 5.0.0@sha256:21687f48522d57a9ebac648f35e388da2c041472565a02141ad1749a55de4292
+    tag: 5.0.1@sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659
   # Liveness probe uses /health/ready (not /health/live) with a high failureThreshold so
   # Kubernetes automatically restarts ZAC after extended OpenZaak/catalogus unavailability.
   # The ZGW-API-Client has no connectTimeout/readTimeout, causing stale TCP connections
@@ -2847,7 +2847,7 @@ zac:
       # -- namespaces to watch for zookeeper-operator
       watchNamespace: "podiumd"
       zookeeper:
-        # pravega/zookeeper:0.2.15@sha256:ac498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8
+        # pravega/zookeeper:0.2.15@sha256:c498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8
         image:
           #repository:
           tag: 0.2.15@sha256:c498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1985,7 +1985,6 @@ openinwoner:
   fullnameOverride: openinwoner
   nginx:
     image:
-      
       tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
     config:
       basicAuth:
@@ -3035,7 +3034,7 @@ apiproxy:
   tolerations: []
   #nameOverride: "iconnect-proxy"
   image:
-    
+    repository: nginxinc/nginx-unprivileged
     tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
     pullPolicy: IfNotPresent
   service:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -687,7 +687,7 @@ openzaak:
         memory: 160Mi
   nginx:
     image:
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     resources:
       requests:
         cpu: 10m
@@ -1357,7 +1357,7 @@ openarchiefbeheer:
 
   nginx:
     image:
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     resources:
       requests:
         cpu: 10m
@@ -1547,7 +1547,7 @@ openklant:
   fullnameOverride: openklant
   nginx:
     image:
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     resources:
       requests:
         cpu: 10m
@@ -1771,7 +1771,7 @@ openformulieren:
         memory: 160Mi
   nginx:
     image:
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     resources:
       requests:
         cpu: 10m
@@ -1985,7 +1985,7 @@ openinwoner:
   fullnameOverride: openinwoner
   nginx:
     image:
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     config:
       basicAuth:
         # Enable this when digid mock is set to digidMock: "true"
@@ -2334,7 +2334,7 @@ openbeheer:
       rateUser: "15000/hour"
   nginx:
     image:
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     resources:
       requests:
         cpu: 10m
@@ -3035,7 +3035,7 @@ apiproxy:
   #nameOverride: "iconnect-proxy"
   image:
     repository: nginxinc/nginx-unprivileged
-    tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+    tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     pullPolicy: IfNotPresent
   service:
     port: 80

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1985,6 +1985,7 @@ openinwoner:
   fullnameOverride: openinwoner
   nginx:
     image:
+      repository: acrprodmgmt.azurecr.io/nginx-unprivileged
       tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
     config:
       basicAuth:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -394,6 +394,11 @@ redis-operator:
   redis-ha:
     enabled: true
     replicaCount: 3
+    # -- Grafana/Loki `app` + `service_name` label for the redis-ha pods (IN-2060).
+    # Without an explicit value the pods inherit `app.kubernetes.io/name: podiumd`
+    # from the shared chart labels and show up in Grafana as "podiumd" instead of
+    # "redis-ha". Set to "" to omit the override.
+    serviceName: redis-ha
     image:
       registry: quay.io
       repository: opstree/redis

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -1985,7 +1985,7 @@ openinwoner:
   fullnameOverride: openinwoner
   nginx:
     image:
-      repository: acrprodmgmt.azurecr.io/nginx-unprivileged
+      
       tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
     config:
       basicAuth:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2847,10 +2847,10 @@ zac:
       # -- namespaces to watch for zookeeper-operator
       watchNamespace: "podiumd"
       zookeeper:
-        # pravega/zookeeper:0.2.15@sha256:b2bc4042fdd8fea6613b04f2f602ba4aff1201e79ba35cd0e2df9f3327111b0e
+        # pravega/zookeeper:0.2.15@sha256:ac498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8
         image:
           #repository:
-          tag: 0.2.15@sha256:b2bc4042fdd8fea6613b04f2f602ba4aff1201e79ba35cd0e2df9f3327111b0e
+          tag: 0.2.15@sha256:c498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8
         resources:
           requests:
             cpu: 100m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2893,6 +2893,12 @@ zgw-office-addin:
     msalTenantId: ""
     # -- MS Azure Client ID assigned to the Office Add-in application
     msalClientId: ""
+    # -- IN-2060: Grafana/Loki app + service_name labels on the office-addin pods.
+    # Without these the pods are attributed to the Helm release name ("podiumd").
+    # Requires zgw-office-addin chart >= 0.0.89 (adds podLabels support).
+    podLabels:
+      app: office-addin
+      service_name: office-addin
   frontend:
     # ghcr.io/infonl/zgw-office-addin-frontend:v0.9.313@sha256:02cbd45a83f09f89b85dcd040840f9fb3e9bbadf67282edd6d258697a68684c7
     image:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2731,10 +2731,10 @@ zac:
   nginx:
     enabled: true
     client_max_body_size: 150M
-    # nginxinc/nginx-unprivileged:1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086
+    # nginxinc/nginx-unprivileged:1.30.0@sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad
     image:
       # repository: nginxinc/nginx-unprivileged
-      tag: "1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086"
+      tag: "1.30.0@sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad"
     resources:
       requests:
         cpu: 50m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2690,11 +2690,11 @@ zac:
     curlImage:
       #repository: curlimages/curl
       tag: "8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a"
-  # ghcr.io/infonl/zaakafhandelcomponent:5.0.0
+  # ghcr.io/infonl/zaakafhandelcomponent:5.1.0
   image:
     #repository: ghcr.io/infonl/zaakafhandelcomponent
     pullPolicy: IfNotPresent
-    tag: 5.0.1@sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659
+    tag: 5.1.0@sha256:d833d2f3dd58eeb58335e9aff9bca67f5885fad0e6a7414003ce9a211d3dc50e
   # Liveness probe uses /health/ready (not /health/live) with a high failureThreshold so
   # Kubernetes automatically restarts ZAC after extended OpenZaak/catalogus unavailability.
   # The ZGW-API-Client has no connectTimeout/readTimeout, causing stale TCP connections
@@ -2731,10 +2731,10 @@ zac:
   nginx:
     enabled: true
     client_max_body_size: 150M
-    # nginxinc/nginx-unprivileged:1.31.1@sha256:24623e90be3447fce56c1d85db722403619f411ab10d1cfd9937a5654f8b6070
+    # nginxinc/nginx-unprivileged:1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61
     image:
       # repository: nginxinc/nginx-unprivileged
-      tag: "1.31.1@sha256:24623e90be3447fce56c1d85db722403619f411ab10d1cfd9937a5654f8b6070"
+      tag: "1.31.1@sha256:9f6b32064a29d747404d959e078c713a0523a9bd4e41f6912058126ebca94e61"
     resources:
       requests:
         cpu: 50m
@@ -2753,10 +2753,10 @@ zac:
       tag: "8.33.0@sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8"
   opa:
     sidecar: true
-    # openpolicyagent/opa:1.16.2-static@sha256:bf5d926c9c5163cd43e56de43f47165d12c1e6a91911d0a20648f8e3ab085a61
+    # openpolicyagent/opa:1.17.1-static@sha256:c29f8ee8dbe66608a1c04e9be84b04efc46877625e6b0877e559954565209efc
     image:
       #repository: openpolicyagent/opa
-      tag: "1.16.2-static@sha256:bf5d926c9c5163cd43e56de43f47165d12c1e6a91911d0a20648f8e3ab085a61"
+      tag: "1.17.1-static@sha256:c29f8ee8dbe66608a1c04e9be84b04efc46877625e6b0877e559954565209efc"
     resources:
       requests:
         cpu: 10m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2646,8 +2646,6 @@ kiss:
       isDefault: true
 
 zac:
-  featureFlags:
-    pabcIntegration: false
   auth:
     server: http://keycloak.example.nl
     realm: podiumd
@@ -2661,7 +2659,9 @@ zac:
     apiKey: "dummy"
   brpApi:
     url: http://brp.example.nl
-    apiKey: "dummy"
+    apiKey:
+      header: "x-api-key"
+      value: "dummy"
     # Protocollering aanbieder mag zijn "", "iConnect", "2Secure"
     protocollering:
       aanbieder: ""
@@ -2690,11 +2690,11 @@ zac:
     curlImage:
       #repository: curlimages/curl
       tag: "8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a"
-  # ghcr.io/infonl/zaakafhandelcomponent:4.9.0
+  # ghcr.io/infonl/zaakafhandelcomponent:5.0.0
   image:
     #repository: ghcr.io/infonl/zaakafhandelcomponent
     pullPolicy: IfNotPresent
-    tag: 4.9.0@sha256:89a4ef1d524fecaafc38f26baec9f1f528230a75ab731a78408cb15850576978
+    tag: 5.0.0@sha256:21687f48522d57a9ebac648f35e388da2c041472565a02141ad1749a55de4292
   # Liveness probe uses /health/ready (not /health/live) with a high failureThreshold so
   # Kubernetes automatically restarts ZAC after extended OpenZaak/catalogus unavailability.
   # The ZGW-API-Client has no connectTimeout/readTimeout, causing stale TCP connections
@@ -2731,10 +2731,10 @@ zac:
   nginx:
     enabled: true
     client_max_body_size: 150M
-    # nginxinc/nginx-unprivileged:1.30.0@sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad
+    # nginxinc/nginx-unprivileged:1.31.1@sha256:24623e90be3447fce56c1d85db722403619f411ab10d1cfd9937a5654f8b6070
     image:
       # repository: nginxinc/nginx-unprivileged
-      tag: "1.30.0@sha256:3def659164dfb7d6be8563983ea9d2fe7e4dfcf2af96770d728723a5c5ad3bad"
+      tag: "1.31.1@sha256:24623e90be3447fce56c1d85db722403619f411ab10d1cfd9937a5654f8b6070"
     resources:
       requests:
         cpu: 50m
@@ -2747,10 +2747,10 @@ zac:
     url: http://objecttypen.example.nl
     token: objecttypentoken
   office_converter:
-    # gotenberg/gotenberg:8.32.0@sha256:a40c5a46b79d812ce2f5e139278163142a054050bfd1e5f162da36d3d11c7138
+    # gotenberg/gotenberg:8.33.0@sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8
     image:
       # repository: gotenberg/gotenberg
-      tag: "8.32.0@sha256:a40c5a46b79d812ce2f5e139278163142a054050bfd1e5f162da36d3d11c7138"
+      tag: "8.33.0@sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8"
   opa:
     sidecar: true
     # openpolicyagent/opa:1.16.2-static@sha256:bf5d926c9c5163cd43e56de43f47165d12c1e6a91911d0a20648f8e3ab085a61
@@ -2795,16 +2795,16 @@ zac:
         cpu: 500m
         memory: 256Mi
     solr:
-      # library/busybox:1.37.0-glibc@sha256:3f9777e7e82e8591542f72b965ec7db7e8b3bdb59692976af1bb9b2850b05a4e
+      # library/busybox:1.38.0-glibc@sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a
       busyBoxImage:
         #repository:
-        tag: 1.37.0-glibc@sha256:3f9777e7e82e8591542f72b965ec7db7e8b3bdb59692976af1bb9b2850b05a4e
+        tag: 1.38.0-glibc@sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a
       # -- set enabled to provision solrcloud as well
       enabled: true
-      # library/solr:9.10.1-slim@sha256:c31309064085bd43b3f368d5fddea34ba5236865647e6427f128b9f3e300da61
+      # library/solr:9.10.1-slim@sha256:f5a742b9476c5608f318432fe142c2e8fe125a846c0ff0081681051e3b2d8eb4
       image:
         #repository:
-        tag: 9.10.1-slim@sha256:c31309064085bd43b3f368d5fddea34ba5236865647e6427f128b9f3e300da61
+        tag: 9.10.1-slim@sha256:f5a742b9476c5608f318432fe142c2e8fe125a846c0ff0081681051e3b2d8eb4
       # -- define memory settings for solr in the solrcloud
       javaMem: -Xms512m -Xmx768m
       jobs:
@@ -2847,10 +2847,10 @@ zac:
       # -- namespaces to watch for zookeeper-operator
       watchNamespace: "podiumd"
       zookeeper:
-        # pravega/zookeeper:0.2.15@sha256:c498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8
+        # pravega/zookeeper:0.2.15@sha256:b2bc4042fdd8fea6613b04f2f602ba4aff1201e79ba35cd0e2df9f3327111b0e
         image:
           #repository:
-          tag: 0.2.15@sha256:c498ebfb76a66f038075e2fa6148528d74d31ca1664f3257fdf82ee779eec9c8
+          tag: 0.2.15@sha256:b2bc4042fdd8fea6613b04f2f602ba4aff1201e79ba35cd0e2df9f3327111b0e
         resources:
           requests:
             cpu: 100m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2730,7 +2730,7 @@ zac:
   nginx:
     enabled: true
     client_max_body_size: 150M
-    # nginxinc/nginx-unprivileged:1.30.1@1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086
+    # nginxinc/nginx-unprivileged:1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086
     image:
       # repository: nginxinc/nginx-unprivileged
       tag: "1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086"

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2888,7 +2888,7 @@ zgw-office-addin:
     # -- Name of the environment (used for display purposes). Default "production" means that no indicator is appended to the DiscplayName in the manifests.
     appEnv: "production"
     # -- The frontend public URL where the manifest files and static js file are served
-    frontendUrl: ""
+    frontendUrl: "https://zgw-office-addin.example.nl"
     # -- MS Azure Tenant ID of the Office Add-in application
     msalTenantId: ""
     # -- MS Azure Client ID assigned to the Office Add-in application
@@ -2912,7 +2912,7 @@ zgw-office-addin:
         memory: 256Mi
     # -- ZGW API configuration for integration with the ZGW APIs provider (OpenZaak)
     zgwApis:
-      url: ""
+      url: "http://open-zaak.example.nl"
       secret: ""
 
 clamav:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2661,15 +2661,28 @@ zac:
     apiKey:
       header: "x-api-key"
       value: "dummy"
-    # Protocollering aanbieder mag zijn "", "iConnect", "2Secure"
+    logLevel: "OFF"
+    # BRP protocollering — see docs/zac-brp-protocollering.md for vendor-specific examples
+    # (iConnect, eServices, 2Secure/EnableU)
     protocollering:
-      aanbieder: ""
-      # Voor aanbieder iConnect worden de volgende "standaard" waardes gebruikt
-      # Voor andere aanbieders zijn deze waardes niet van belang en worden niet gebruikt
+      enabled: false
+      # systemUser: "SystemUser"  # required for iConnect and 2Secure; omit for eServices
+      originOin:
+        oin: ""               # gemeentelijke OIN
+        header: ""            # iConnect: "x-origin-oin" | eServices: "x-request-organization"
       doelbinding:
-        zoekmet: "BRPACT-ZoekenAlgemeen"
-        raadpleegmet: "BRPACT-ZacPersoonBasis"
-      verwerkingsregister: "DigitaleDienstverlening"
+        perZaaktype: false    # true for iConnect
+        header: ""            # iConnect: "x-doelbinding" | eServices: ""
+        zoekmet: "BRPACT-ZoekenAlgemeen"      # iConnect only
+        raadpleegmet: "BRPACT-ZacPersoonBasis"  # iConnect only
+      verwerking:
+        header: ""            # iConnect/2Secure: "x-verwerking" | eServices: "x-request-afnemerscode"
+        register: ""          # iConnect: "DigitaleDienstverlening"
+      gebruiker:
+        header: ""            # iConnect/2Secure: "x-gebruiker" | eServices: "x-request-user"
+      toepassing:
+        header: ""            # iConnect: "x-toepassing" | eServices: "x-request-application" | 2Secure: "x-applicatie"
+        value: ""
   catalogusDomein: ALG
   contextUrl: http://zac.example.nl
   db:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2690,11 +2690,11 @@ zac:
     curlImage:
       #repository: curlimages/curl
       tag: "8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a"
-  # ghcr.io/infonl/zaakafhandelcomponent:5.1.0
+  # ghcr.io/infonl/zaakafhandelcomponent:5.0.1
   image:
     #repository: ghcr.io/infonl/zaakafhandelcomponent
     pullPolicy: IfNotPresent
-    tag: 5.1.0@sha256:d833d2f3dd58eeb58335e9aff9bca67f5885fad0e6a7414003ce9a211d3dc50e
+    tag: 5.0.1@sha256:8c7844248b7decf56eafc0d2aca1f9e080f94e9bf2f6b6ac412589deb80d1659
   # Liveness probe uses /health/ready (not /health/live) with a high failureThreshold so
   # Kubernetes automatically restarts ZAC after extended OpenZaak/catalogus unavailability.
   # The ZGW-API-Client has no connectTimeout/readTimeout, causing stale TCP connections

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2689,11 +2689,11 @@ zac:
     curlImage:
       #repository: curlimages/curl
       tag: "8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a"
-  # ghcr.io/infonl/zaakafhandelcomponent:4.7.2
+  # ghcr.io/infonl/zaakafhandelcomponent:4.9.0
   image:
     #repository: ghcr.io/infonl/zaakafhandelcomponent
     pullPolicy: IfNotPresent
-    tag: 4.7.2@sha256:235e51559f3439bb6aba5bbbc67279d70e9ab141aefd43d85be546d420fb0e34
+    tag: 4.9.0@sha256:89a4ef1d524fecaafc38f26baec9f1f528230a75ab731a78408cb15850576978
   # Liveness probe uses /health/ready (not /health/live) with a high failureThreshold so
   # Kubernetes automatically restarts ZAC after extended OpenZaak/catalogus unavailability.
   # The ZGW-API-Client has no connectTimeout/readTimeout, causing stale TCP connections
@@ -2730,10 +2730,10 @@ zac:
   nginx:
     enabled: true
     client_max_body_size: 150M
-    # nginxinc/nginx-unprivileged:1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879
+    # nginxinc/nginx-unprivileged:1.30.1@1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086
     image:
       # repository: nginxinc/nginx-unprivileged
-      tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
+      tag: "1.30.1@sha256:6f5c8f8836fce1eba7daa6b4f0dbfe7aa742be47e1b15386a67be7a3dbd06086"
     resources:
       requests:
         cpu: 50m
@@ -2746,16 +2746,16 @@ zac:
     url: http://objecttypen.example.nl
     token: objecttypentoken
   office_converter:
-    # gotenberg/gotenberg:8.31.0@sha256:f0d86e8a1dbc7b33a5a65cb251d02bb271a48ffa989da3feb5ed7d954fe4d4b3
+    # gotenberg/gotenberg:8.32.0@sha256:a40c5a46b79d812ce2f5e139278163142a054050bfd1e5f162da36d3d11c7138
     image:
       # repository: gotenberg/gotenberg
-      tag: "8.31.0@sha256:f0d86e8a1dbc7b33a5a65cb251d02bb271a48ffa989da3feb5ed7d954fe4d4b3"
+      tag: "8.32.0@sha256:a40c5a46b79d812ce2f5e139278163142a054050bfd1e5f162da36d3d11c7138"
   opa:
     sidecar: true
-    # openpolicyagent/opa:1.15.2-static@sha256:f3429de096f6d274bd9927f7a50c334e340a6cf206fad9460ccf17e2f3e807bf
+    # openpolicyagent/opa:1.16.2-static@sha256:bf5d926c9c5163cd43e56de43f47165d12c1e6a91911d0a20648f8e3ab085a61
     image:
       #repository: openpolicyagent/opa
-      tag: "1.15.2-static@sha256:f3429de096f6d274bd9927f7a50c334e340a6cf206fad9460ccf17e2f3e807bf"
+      tag: "1.16.2-static@sha256:bf5d926c9c5163cd43e56de43f47165d12c1e6a91911d0a20648f8e3ab085a61"
     resources:
       requests:
         cpu: 10m
@@ -2800,10 +2800,10 @@ zac:
         tag: 1.37.0-glibc@sha256:3f9777e7e82e8591542f72b965ec7db7e8b3bdb59692976af1bb9b2850b05a4e
       # -- set enabled to provision solrcloud as well
       enabled: true
-      # library/solr:9.10.1-slim@sha256:f5a742b9476c5608f318432fe142c2e8fe125a846c0ff0081681051e3b2d8eb4
+      # library/solr:9.10.1-slim@sha256:c31309064085bd43b3f368d5fddea34ba5236865647e6427f128b9f3e300da61
       image:
         #repository:
-        tag: 9.10.1-slim@sha256:f5a742b9476c5608f318432fe142c2e8fe125a846c0ff0081681051e3b2d8eb4
+        tag: 9.10.1-slim@sha256:c31309064085bd43b3f368d5fddea34ba5236865647e6427f128b9f3e300da61
       # -- define memory settings for solr in the solrcloud
       javaMem: -Xms512m -Xmx768m
       jobs:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -3035,7 +3035,7 @@ apiproxy:
   tolerations: []
   #nameOverride: "iconnect-proxy"
   image:
-    repository: nginxinc/nginx-unprivileged
+    
     tag: "1.30.2@sha256:1d13071bcebdfc6866d68954b30c84551ca0965ae65df7b5f6888bceb3e3a879"
     pullPolicy: IfNotPresent
   service:


### PR DESCRIPTION
## Summary

- Rebases the info.nl ZAC 5.0.1 work onto `feature/podiumd-4.8.0` (PodiumD 4.8.0 base)
- Bumps ZAC from 4.7.2 → 5.0.1 (helm chart `1.0.228` → `1.0.251`)
- Aligns all `nginx-unprivileged` pins to `1.31.1` across all components
- Restructures `zac.brpApi.protocollering` to the new ZAC 5.x explicit field-per-dimension format
- Adds `zac.brpApi.logLevel`
- Removes `zac.featureFlags.pabcIntegration` (dropped in ZAC 5.x)

## Changes

**`charts/podiumd/Chart.yaml`**
- ZAC helm chart `1.0.228` → `1.0.251`

**`charts/podiumd/values.yaml`**
- ZAC image `4.7.2` → `5.0.1`
- All `nginx-unprivileged` pins `1.30.2` → `1.31.1` (9 occurrences)
- ZAC sub-images: nginx `1.31.1`, gotenberg `8.33.0`, OPA `1.17.1-static`, busybox `1.38.0-glibc`
- `zac.brpApi.protocollering` restructured (aanbieder removed, explicit header/value fields added)
- `zac.brpApi.logLevel: "OFF"` added
- `zac.featureFlags.pabcIntegration` removed
- `zac.brpApi.apiKey` changed from string to `{header, value}` object
- `zgw-office-addin` placeholder URLs changed from `""` to `*.example.nl` (fixes schema lint)

**Docs**
- `docs/images/images-4.8.0.yaml`: ZAC 5.0.1 and sub-image entries added
- `docs/upgrade-from-4.7.5-to-4.8.0.md` / `upgrade-from-4.7.3-to-4.8.0.md`: ZAC 5.0.1 section with all breaking changes
- `docs/values-changes-4.8.0.md`: ZAC breaking-change entries
- `docs/zac-brp-protocollering.md`: new vendor reference doc (iConnect, eServices, 2Secure/EnableU) with api-proxy interaction notes
- `docs/UPGRADING.md`: reference entries for new docs

## Test plan

- [x] `helm lint charts/podiumd` — only pre-existing KISS schema failures remain (zgw-office-addin errors resolved)
- [x] No duplicate YAML keys in `values.yaml` (helm-dupecheck clean)
- [x] Verify gemeente `podiumd.yml` overrides for `zac.brpApi.apiKey` use the new `{header, value}` object form
- [x] Verify gemeente files with iConnect protocollering are updated to the new explicit field structure and `apiproxy.locations.brp.toepassingHeaderName` is set to `""`
- [x] Verify gemeente files with `zac.featureFlags.pabcIntegration` have that key removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)