### PR TITLE
IN-2060: redis-ha Grafana app/service_name label (configurable)

### DIFF
--- a/charts/podiumd/templates/redis-ha.yaml
+++ b/charts/podiumd/templates/redis-ha.yaml
@@ -22,6 +22,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "podiumd.labels" . | nindent 4 }}
+    {{- with $redisHa.serviceName }}
+    app: {{ . }}
+    service_name: {{ . }}
+    {{- end }}
 spec:
   clusterSize: {{ $redisHa.replicaCount }}
   kubernetesConfig:

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -394,6 +394,11 @@ redis-operator:
   redis-ha:
     enabled: true
     replicaCount: 3
+    # -- Grafana/Loki `app` + `service_name` label for the redis-ha pods (IN-2060).
+    # Without an explicit value the pods inherit `app.kubernetes.io/name: podiumd`
+    # from the shared chart labels and show up in Grafana as "podiumd" instead of
+    # "redis-ha". Set to "" to omit the override.
+    serviceName: redis-ha
     image:
       registry: quay.io
       repository: opstree/redis


### PR DESCRIPTION
## IN-2060 — redis-ha shows as `podiumd` in Grafana

### Cause
The redis-ha `RedisReplication` carried the shared `podiumd.labels` (`app.kubernetes.io/name: podiumd`); the OT operator propagates these to the pods, so Grafana/Loki surfaced them as `app=podiumd` / `service_name=podiumd`.

### Fix (redis-ha) — this PR
- `templates/redis-ha.yaml`: add explicit `app` + `service_name` labels on the `RedisReplication` metadata (propagated to the pods).
- Configurable via **`redis-operator.redis-ha.serviceName`** (default `redis-ha`; empty string omits the override).

Now redis-ha pods carry `app: redis-ha` / `service_name: redis-ha`.

### office-addin — NOT fixable in this chart (needs upstream)
zgw-office-addin is a subchart (`infonl/zgw-office-addin`). Its pod labels come from hardcoded `selectorLabels` (`app.kubernetes.io/name: backend`/`frontend` + `app.kubernetes.io/instance: <release>`=`podiumd`) with **no `app`/`service_name` label and no `podLabels`/`commonLabels`/`extraLabels` knob** — so nothing in the podiumd chart can relabel its pods. Requires an upstream change to the `office-add-in` chart (add `podLabels`/`commonLabels` support, or emit `app`/`service_name` = office-addin). Tracking separately.

### Test
`helm template` renders the two extra labels on the RedisReplication; verify on cluster that redis-ha pods show `service_name=redis-ha` in Grafana after rollout.