### PR TITLE
PodiumD 4.8.0: opennotificaties 1.13.1 -> 2.0.0 (Notificaties 1.16.0) [IN-2348]

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: "@maykinmedia"
     condition: openzaak.enabled
   - name: opennotificaties
-    version: 1.13.1
+    version: 2.0.0
     repository: "@maykinmedia"
     condition: opennotificaties.enabled
   - name: objecten

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -46,12 +46,6 @@
   version: "3.2.0"
   digest: "sha256:eee4567fd5bfaa7eb2ec13fa1a34cfabb402939ffdc79de8159f5dc00754bafb"
 
-# Open Notificaties — 1.15.0 -> 1.16.0 (helm chart opennotificaties 1.13.1 -> 2.0.0; RabbitMQ verwijderd, Celery op Redis)
-- name: open-notificaties
-  url: docker.io/openzaak/open-notificaties
-  version: "1.16.0"
-  digest: "sha256:416f0949f6bf08f430b19ebfb3013963842e7ea59b2c3e4898782a8252a1257c"
-
 # Renovate dependency bumps integrated into 4.8.0 (PRs #292, #324, #334).
 # Digests verified live against the source registry (Docker-Content-Digest).
 # PR #294 (azure/k8s-bake v3 -> v4) is a GitHub Action, not a container image,

--- a/charts/podiumd/docs/images/images-4.8.0.yaml
+++ b/charts/podiumd/docs/images/images-4.8.0.yaml
@@ -46,6 +46,12 @@
   version: "3.2.0"
   digest: "sha256:eee4567fd5bfaa7eb2ec13fa1a34cfabb402939ffdc79de8159f5dc00754bafb"
 
+# Open Notificaties — 1.15.0 -> 1.16.0 (helm chart opennotificaties 1.13.1 -> 2.0.0; RabbitMQ verwijderd, Celery op Redis)
+- name: open-notificaties
+  url: docker.io/openzaak/open-notificaties
+  version: "1.16.0"
+  digest: "sha256:416f0949f6bf08f430b19ebfb3013963842e7ea59b2c3e4898782a8252a1257c"
+
 # Renovate dependency bumps integrated into 4.8.0 (PRs #292, #324, #334).
 # Digests verified live against the source registry (Docker-Content-Digest).
 # PR #294 (azure/k8s-bake v3 -> v4) is a GitHub Action, not a container image,

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -895,23 +895,10 @@ opennotificaties:
         memory: 128Mi
   flower:
     enabled: false
-  rabbitmq:
-    image:
-      registry: docker.io
-      repository: bitnamilegacy/rabbitmq
-      tag: 4.1.3-debian-12-r0
-    resources:
-      requests:
-        cpu: 300m
-        memory: 256Mi
-    nameOverride: opennotificaties-rabbitmq
-    fullnameOverride: opennotificaties-rabbitmq
-    auth:
-      username: guest
-      password: guest
-      erlangCookie: SUPER-SECRET
+  # RabbitMQ verwijderd in chart 2.0.0 (app 1.16.0): Celery gebruikt nu Redis voor broker +
+  # result-backend via de redis-subchart, daarom tags.redis: true (was false met RabbitMQ-broker).
   tags:
-    redis: false
+    redis: true
   # override: values-enable-observability.yaml sets disabled: false and configures the OTLP endpoint
   otel:
     disabled: true

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -872,7 +872,7 @@ opennotificaties:
     volumeAttributeShareName: opennotificaties
     storageClassName: podiumd-standard
   image:
-    tag: "1.15.0"
+    tag: "1.16.0"
   resources:
     requests:
       cpu: 100m

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -380,7 +380,7 @@ redis-operator:
   # Database allocation:
   #   objecttypen        : db 0  (cache)
   #   objecten           : db 1  (cache), db 2  (celery)
-  #   opennotificaties   : db 3  (cache), db 6  (celery result backend; broker stays on RabbitMQ)
+  #   opennotificaties   : db 3  (cache), db 6  (celery result backend; broker nu ook Redis i.p.v. RabbitMQ vanaf chart 2.0.0)
   #   openzaak           : db 4  (cache), db 5  (celery)
   #   openklant          : db 7  (cache), db 8  (celery)
   #   openformulieren    : db 9  (cache), db 10 (celery)


### PR DESCRIPTION
## Wat
Bump opennotificaties helm-chart **1.13.1 -> 2.0.0** (app/Notificaties **1.16.0**) voor podiumd 4.8.0.

## Breaking value-changes (chart 2.0.0)
- RabbitMQ is uit de chart verwijderd -> `rabbitmq`-blok uit `values.yaml` gehaald.
- Celery gebruikt nu Redis (broker + result-backend) -> `opennotificaties.tags.redis: false` -> **true** (redis-subchart levert de broker).

## Getest
Uitgerold + gevalideerd op **podiumd-test**: Celery connected to `redis://opennotificaties-redis-master`, notification-taken received + succeeded, geen rabbitmq meer.

Ticket: IN-2348