### PR TITLE
fix(keycloak-operator): pin RELATED_IMAGE_KEYCLOAK to refreshed 26.6.3 digest

### DIFF
--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -51,6 +51,18 @@ keycloak-operator:
         cpu: 500m
         # IN-2233: operator OOMKilled at 256Mi limit (excessive restarts across clusters); raised to 768Mi.
         memory: 768Mi
+    # Default Keycloak SERVER image the operator stamps onto Keycloak CRs it
+    # provisions (RELATED_IMAGE_KEYCLOAK env on the operator Deployment). Must
+    # match podiumd's own `keycloak.image` digest above. The adfinis subchart's
+    # built-in default still carries the pre-PR#344 digest (sha256:5fdbf2d…), so
+    # we override it here to the refreshed 26.6.3 digest (sha256:9b03307…).
+    # NOTE: sha is a SEPARATE field; the template appends it as @sha256:{{ .sha }},
+    # so do NOT embed @sha256 in tag (would produce a double digest).
+    config:
+      keycloakImage:
+        repository: quay.io/keycloak/keycloak
+        tag: "26.6.3"
+        sha: "9b0330756022422149aa6502eb2def8cd47c6e1b000c7c65cdb13e7c0133e992"
   serviceAccount:
     create: false
   jobs:


### PR DESCRIPTION
## What

Override `keycloak-operator.operator.config.keycloakImage` in `charts/podiumd/values.yaml` to pin the operator's default Keycloak **server** image to the refreshed `26.6.3` digest `sha256:9b03307…`.

## Why

The adfinis `keycloak-operator` subchart (1.12.0) ships a built-in default `operator.config.keycloakImage.sha` of `sha256:5fdbf2d…` — the **pre-PR#344** `26.6.3` digest. PR #344 refreshed podiumd's own `keycloak.image` (the StatefulSet image) to `sha256:9b03307…`, but the operator's default image — stamped onto Keycloak CRs it provisions via the `RELATED_IMAGE_KEYCLOAK` env on the operator Deployment — was left on the stale digest.

Result: same tag `26.6.3`, two different digests in one release. Pods run `9b03307`, but operator-provisioned Keycloak CRs would have hinted `5fdbf2d`.

## Fix

```yaml
keycloak-operator:
  operator:
    config:
      keycloakImage:
        repository: quay.io/keycloak/keycloak
        tag: "26.6.3"
        sha: "9b0330756022422149aa6502eb2def8cd47c6e1b000c7c65cdb13e7c0133e992"
```

(`sha` is a separate field the subchart appends as `@sha256:{{ .sha }}` — not embedded in `tag`, to avoid a double digest.)

## Validation

`helm template podiumd -f ci/lint-values.yaml` (with office-addin dummy uris for the pre-existing schema gate):
- All `keycloak:26.6.3` **server** refs → `sha256:9b03307…` (3/3, was 2× 9b03307 + 1× 5fdbf2d).
- `RELATED_IMAGE_KEYCLOAK` env → `sha256:9b03307…`.
- Operator image unchanged: `keycloak-operator:26.6.3@sha256:bd128cd6…`.
- **No double-`@sha256`** anywhere in the render.
