### PR TITLE
PodiumD 4.7.7

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.7.6
-appVersion: "4.7.6"
+version: 4.7.7
+appVersion: "4.7.7"
 dependencies:
   - name: keycloak-operator
     version: 1.12.0

--- a/charts/podiumd/docs/UPGRADING.md
+++ b/charts/podiumd/docs/UPGRADING.md
@@ -7,7 +7,7 @@ files required for each hop, and which guides are reference-only.
 ## Official upgrade path
 
 ```
-4.5.15 ─▶ 4.5.16 ─▶ 4.6.4 ─▶ 4.6.8 ─▶ 4.7.3 ─▶ 4.7.4 ─▶ 4.7.5 ─▶ 4.7.6
+4.5.15 ─▶ 4.5.16 ─▶ 4.6.4 ─▶ 4.6.8 ─▶ 4.7.3 ─▶ 4.7.4 ─▶ 4.7.5 ─▶ 4.7.6 ─▶ 4.7.7
 ```
 
 Upgrade one hop at a time, in order. Each hop has exactly **one** upgrade guide
@@ -22,6 +22,7 @@ and a matching image manifest (the ACR-mirror set for that hop):
 | 4.7.3 → 4.7.4   | [`upgrade-from-4.7.3-to-4.7.4.md`](upgrade-from-4.7.3-to-4.7.4.md)   | [`images/images-4.7.4.yaml`](images/images-4.7.4.yaml) |
 | 4.7.4 → 4.7.5   | [`upgrade-from-4.7.4-to-4.7.5.md`](upgrade-from-4.7.4-to-4.7.5.md)   | [`images/images-4.7.5.yaml`](images/images-4.7.5.yaml) |
 | 4.7.5 → 4.7.6   | [`upgrade-from-4.7.5-to-4.7.6.md`](upgrade-from-4.7.5-to-4.7.6.md)   | — (docs/config only, no image changes) |
+| 4.7.6 → 4.7.7   | [`upgrade-from-4.7.6-to-4.7.7.md`](upgrade-from-4.7.6-to-4.7.7.md)   | [`images/images-4.7.7.yaml`](images/images-4.7.7.yaml) |
 
 > The 4.6.4 → 4.6.8 and 4.6.8 → 4.7.3 guides are **consolidated**: each folds
 > several intermediate releases into one document so an operator reads one

--- a/charts/podiumd/docs/images/images-4.7.7.yaml
+++ b/charts/podiumd/docs/images/images-4.7.7.yaml
@@ -1,0 +1,13 @@
+# Images new or changed in podiumd 4.7.7 vs 4.7.6.
+#
+# 4.7.7 is a direct successor of 4.7.6 (no skipped intermediate releases),
+# so this manifest is the plain 4.7.6 -> 4.7.7 delta.
+#
+# One image change:
+#  - Open Zaak 1.27.2 -> 1.27.3
+
+# Open Zaak — 1.27.2 -> 1.27.3
+- name: openzaak
+  url: docker.io/openzaak/open-zaak
+  version: "1.27.3"
+  digest: "sha256:b2732761c15b9b35d9a59420e01de0bd099266be96819e65be9f4e01fca11a63"

--- a/charts/podiumd/docs/upgrade-from-4.7.6-to-4.7.7.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.6-to-4.7.7.md
@@ -1,0 +1,20 @@
+# Upgrade guide: PodiumD 4.7.6 → 4.7.7
+
+4.7.7 is a small patch release: it bumps **Open Zaak** only. No other
+components change.
+
+## Changes
+
+### Open Zaak `1.27.2` → `1.27.3`
+
+- Image tag override updated to `1.27.3` (digest-pinned) in
+  `charts/podiumd/values.yaml`. The `openzaak` chart dependency stays `1.14.1`.
+
+Image / digest: see [`docs/images/images-4.7.7.yaml`](images/images-4.7.7.yaml).
+
+#### Action required
+
+- **Standard image-pin update** — the pin is already in `values.yaml` and
+  `images/images-4.7.7.yaml`.
+- **ACR-mirror environments:** mirror `docker.io/openzaak/open-zaak:1.27.3`.
+- No config, schema, or migration changes.

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -662,7 +662,7 @@ openzaak:
     volumeAttributeShareName: openzaak
     storageClassName: podiumd-standard
   image:
-    tag: "1.27.2@sha256:7f4826298b1bb28aca3f1f6d18fbad52238267eafc5253c68fb067f3afe8908e"
+    tag: "1.27.3@sha256:b2732761c15b9b35d9a59420e01de0bd099266be96819e65be9f4e01fca11a63"
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
## Summary

- Bump Open Zaak `1.27.2` → `1.27.3` (image-pin override in `values.yaml`; `openzaak` chart dependency stays `1.14.1`)
- Add `docs/images/images-4.7.7.yaml` (delta manifest: one image)
- Add `docs/upgrade-from-4.7.6-to-4.7.7.md` (upgrade guide)
- Extend official upgrade path in `docs/UPGRADING.md` to `─▶ 4.7.7`

## Test plan

- [x] `/verify-image-digests` — confirm Open Zaak digest matches `images-4.7.7.yaml`
- [x] `/helm-dupecheck` — no duplicate image pins
- [x] `/helm-lint` — chart lints cleanly