### PR TITLE
fix(openzaak): override OPENZAAK_PORT to prevent K8s service env collision (IN-2384)

### DIFF
--- a/charts/podiumd/Chart.yaml
+++ b/charts/podiumd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: podiumd
 description: PodiumD Helm chart
 type: application
-version: 4.7.7
-appVersion: "4.7.7"
+version: 4.7.8
+appVersion: "4.7.8"
 dependencies:
   - name: keycloak-operator
     version: 1.12.0

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -676,6 +676,14 @@ openzaak:
       requests:
         cpu: 200m
         memory: 1Gi
+  # -- Override OPENZAAK_PORT to prevent Kubernetes service-discovery injection
+  # (tcp://<ip>:80) from being passed to uwsgi as the port number.
+  # Since Open Zaak 1.27.3 the app reads OPENZAAK_PORT for uwsgi_port; K8s
+  # auto-injects OPENZAAK_PORT=tcp://<svc-ip>:80 for the openzaak Service,
+  # which uwsgi cannot parse. See https://github.com/open-zaak/open-zaak/issues/2415
+  extraEnvVars:
+    - name: OPENZAAK_PORT
+      value: "8000"
   nameOverride: openzaak
   fullnameOverride: openzaak
   flower:


### PR DESCRIPTION
## Summary

- Adds `extraEnvVars: [{name: OPENZAAK_PORT, value: "8000"}]` to the `openzaak` section in `charts/podiumd/values.yaml`
- Prevents Kubernetes service-discovery injection (`OPENZAAK_PORT=tcp://<ip>:80`) from being passed to uwsgi as the port number
- Since Open Zaak 1.27.3 the app reads `OPENZAAK_PORT` for the uwsgi port; without this fix the pod fails to start with _Progress deadline exceeded_

## Root cause

Kubernetes automatically injects `OPENZAAK_PORT=tcp://<svc-ip>:80` into every pod in the namespace (standard service env vars for a Service named `openzaak`). Open Zaak ≥ 1.27.3 now uses `OPENZAAK_PORT` to configure the uwsgi port number. uwsgi cannot parse `tcp://10.0.x.x:80` and crashes on startup.

Upstream issue: https://github.com/open-zaak/open-zaak/issues/2415

## Test plan

- [x] Deploy podiumd with this change and confirm the `openzaak` Deployment reaches `Available` without _Progress deadline exceeded_
- [ ] Verify `kubectl exec` into the openzaak pod shows `OPENZAAK_PORT=8000`
- [ ] Confirm existing Open Zaak functionality (API, admin) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)