### PR TITLE
feat(podiumd): install ECK CRDs via the chart (IN-2402)

### DIFF
--- a/charts/podiumd/docs/migrating-to-eck-stack.md
+++ b/charts/podiumd/docs/migrating-to-eck-stack.md
@@ -97,9 +97,9 @@ a separate step with snapshot/restore.
 ## 4. Migration steps for SSC (environment already running)
 
 The KISS Elasticsearch migration itself is a metadata-only change (see section
-2). The only real point of attention is **how you handle the operator** when an
-environment already runs a standalone `elastic-operator` Helm release (installed
-outside the umbrella).
+2). The two real points of attention are **how you handle the operator** when
+an environment already runs a standalone `elastic-operator` Helm release
+(installed outside the umbrella), and the **ECK CRDs** (section 4b).
 
 ### 4a. Decide how the operator is managed
 
@@ -142,7 +142,76 @@ done
 
 </details>
 
-### 4b. The upgrade
+### 4b. CRDs: installed by the chart (one-time adoption on existing clusters)
+
+The umbrella installs and upgrades the ECK CRDs itself
+(`eck-operator.installCRDs: true`, the upstream default): all **12**
+`*.k8s.elastic.co` CRDs are applied on every deploy, in lock-step with the
+operator version — no manual step on version bumps. The CRDs carry
+`helm.sh/resource-policy: keep`, so `helm uninstall` never removes them and
+the Elastic CRs (and their data) survive a release removal.
+
+Two requirements:
+
+1. **Cluster-scope RBAC.** CRDs are cluster-scoped, so the deploying identity
+   must be allowed to create/update them. The SSC deploy pipeline runs
+   `HelmDeploy` with `useClusterAdmin: true`, which covers this.
+2. **One-time adoption on clusters that already have the CRDs.** CRDs applied
+   in the kisselastic era (or by a manual `kubectl apply`) have no Helm
+   ownership metadata, and Helm refuses to overwrite them (`rendered manifests
+   contain a resource that already exists ... invalid ownership metadata`).
+   Either deploy with `--take-ownership` (helm >= 3.17; safe to keep in the
+   pipeline permanently), or annotate the CRDs once:
+
+   ```bash
+   for crd in $(kubectl get crd -o name | grep 'k8s.elastic.co'); do
+     kubectl annotate "${crd}" meta.helm.sh/release-name=podiumd \
+       meta.helm.sh/release-namespace=podiumd --overwrite
+     kubectl label "${crd}" app.kubernetes.io/managed-by=Helm --overwrite
+   done
+   ```
+
+Verify after the deploy (must print `12`):
+
+```bash
+kubectl get crd -o name | grep -c 'k8s.elastic.co'
+```
+
+**Symptom of missing/stale CRDs** (e.g. `installCRDs` overridden to `false`
+without a manual apply): ECK operator 3.4.0 needs 12 CRDs; kisselastic-era
+clusters have only 10 — `packageregistries.packageregistry.k8s.elastic.co`
+and `autoopsagentpolicies.autoops.k8s.elastic.co` are missing. The operator's
+informer cache then cannot sync (`failed to wait for packageregistry-controller
+caches to sync`), the process exits cleanly every ~2 minutes (exit code 0) and
+the `elastic-operator` StatefulSet ends up in `CrashLoopBackOff`. Treacherous:
+`helm --wait` can sample the operator during an up-phase, so a deploy may
+**intermittently go green** while the operator is broken — the failure then
+surfaces on a later rollout. After fixing the CRDs, delete the operator pod
+once to skip the remaining backoff:
+`kubectl delete pod elastic-operator-0 -n podiumd`.
+
+<details>
+<summary>Installers without cluster-scope RBAC: manual CRD apply</summary>
+
+Set `eck-operator.installCRDs: false` and apply the CRDs manually before the
+upgrade (cluster-admin, repeat on every operator version bump). The CRDs are
+too large for client-side apply, hence `--server-side`:
+
+```bash
+# Option A — render from the chart's own bundled eck-operator (version always matches)
+tar -xzf charts/podiumd/charts/eck-operator-3.4.0.tgz -C /tmp
+helm template eck /tmp/eck-operator --set installCRDs=true \
+  --show-only charts/eck-operator-crds/templates/all-crds.yaml > /tmp/eck-crds.yaml
+kubectl apply --server-side --force-conflicts -f /tmp/eck-crds.yaml
+
+# Option B — upstream, same content (needs internet egress)
+kubectl apply --server-side --force-conflicts \
+  -f https://download.elastic.co/downloads/eck/3.4.0/crds.yaml
+```
+
+</details>
+
+### 4c. The upgrade
 
 1. Make a backup/snapshot of the Elasticsearch data (or at least record the
    index/doc counts, see section 5).
@@ -168,6 +237,16 @@ kubectl exec -n $NS kiss-es-default-0 -c elasticsearch -- \
 
 After the upgrade the StatefulSet UID, PVCs and doc counts must be unchanged and
 the `Elasticsearch` health must be `green`.
+
+Also verify the **operator stays up**. The CRD failure mode (section 4b) exits
+every ~2 minutes, so a single `Running` sample proves nothing — check the
+restart count after at least 5 minutes:
+
+```bash
+kubectl get pod elastic-operator-0 -n $NS \
+  -o jsonpath='{.status.containerStatuses[0].restartCount}{"\n"}'
+# must stay 0 (and AGE keeps growing)
+```
 
 ### Validation test result
 With a realistic data baseline (475 documents: `search-kennisbank` +

--- a/charts/podiumd/docs/upgrade-from-4.7.6-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.6-to-4.8.0.md
@@ -40,6 +40,7 @@ this guide.
 | ZAC                 | 5.0.1 | 1.0.251 | **action required** |
 | PABC                | 1.1.0 | 1.1.0 | **action required** (now enabled by default) |
 | redis-operator      | v0.25.0 | -- | expect redis rolling restart |
+| ECK operator        | 3.4.0 | eck-operator 3.4.0 + eck-stack 0.19.0 | **action required** (values migration + one-time CRD adoption) |
 
 ## Changes
 
@@ -177,6 +178,31 @@ running pod image with
 `kubectl get pod <es-pod> -o jsonpath='{.spec.containers[*].image}'` — it
 must read `…/elasticsearch/elasticsearch:9.2.0`, not `:latest`.
 
+
+### ECK stack: kisselastic → central eck-operator + kiss-eck
+
+4.8.0 replaces the legacy `kiss-elastic` subchart with Elastic's official
+charts: one **central** root-level `eck-operator` (3.4.0) plus `eck-stack`
+(0.19.0, alias `kiss-eck`) for the KISS Elasticsearch. The swap itself is
+metadata-only — StatefulSet, PVCs and data are preserved. Full runbook:
+[`migrating-to-eck-stack.md`](migrating-to-eck-stack.md).
+
+**Action required:**
+
+1. **Migrate gemeente values:** remove the `kisselastic:` block, add
+   root-level `eck-operator:` + `kiss-eck:` blocks (runbook section 3). Keep
+   the nodeSet name `default` and leave `volumeClaimTemplates` unchanged
+   during the migration.
+2. **One-time CRD adoption.** The chart now installs and upgrades the 12 ECK
+   CRDs itself (`eck-operator.installCRDs: true`), so CRDs stay in lock-step
+   with the operator automatically. On clusters where the CRDs already exist
+   without Helm ownership (kisselastic era), the first deploy must run with
+   `--take-ownership`, or the CRDs must be annotated once — commands and
+   details in runbook section 4b. Skipping this fails the deploy with
+   `invalid ownership metadata`; deploying with **stale** CRDs crashloops the
+   operator (also section 4b).
+3. **ACR mirror:** mirror `elastic/eck-operator:3.4.0` (see
+   [`docs/images/images-baseline.yaml`](images/images-baseline.yaml)).
 
 ### Open Notificaties 1.13.1 → 2.0.0 (app 1.16.0) — RabbitMQ removed
 

--- a/charts/podiumd/values.yaml
+++ b/charts/podiumd/values.yaml
@@ -2374,9 +2374,16 @@ openbeheer:
 # subchart. See docs/migrating-to-eck-stack.md.
 eck-operator:
   enabled: true
-  # -- install crds using https://github.com/elastic/cloud-on-k8s/blob/main/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+  # -- the chart installs and upgrades the 12 *.k8s.elastic.co CRDs, in lock-step
+  # with the operator version. The CRDs carry helm.sh/resource-policy: keep, so
+  # `helm uninstall` never removes them (the Elastic CRs and their data survive).
+  # Requires cluster-scope RBAC on the deploying identity. Clusters whose CRDs
+  # predate helm ownership (kisselastic era / manual apply) need a one-time
+  # adoption: deploy with `--take-ownership` (helm >= 3.17) or annotate the CRDs
+  # once — see docs/migrating-to-eck-stack.md section 4b. Installers without
+  # cluster-scope RBAC: set false and apply the CRDs manually (same doc).
   # override: values-enable-observability.yaml sets config.metricsPort and enables podMonitor
-  installCRDs: false
+  installCRDs: true
   createClusterScopedResources: false
   config:
     # no RBAC access to cluster-wide storage classes, hence disable storage class validation


### PR DESCRIPTION
## What

- `eck-operator.installCRDs: true` in `charts/podiumd/values.yaml` (upstream default): helm installs and **upgrades** the 12 `*.k8s.elastic.co` CRDs on every deploy, in lock-step with the operator version.
- `docs/migrating-to-eck-stack.md`: new §4b — CRDs installed by the chart, one-time adoption on existing clusters (`--take-ownership` or annotate loop), verification steps, crashloop symptom, manual fallback for installers without cluster-scope RBAC.
- `docs/upgrade-from-4.7.6-to-4.8.0.md`: ECK component row marked **action required**; new section covering values migration + one-time CRD adoption.

## Why (IN-2402)

ECK operator 3.4.0 requires 12 CRDs; clusters from the kisselastic era (ECK 2.9) have 10 — missing `packageregistries.packageregistry.k8s.elastic.co` and `autoopsagentpolicies.autoops.k8s.elastic.co`. The operator's informer cache can't sync, it exits cleanly every ~2 min (CrashLoopBackOff), and `helm --wait` can sample an up-phase so a deploy *sometimes still goes green* (dim1 run 33307 green, 33308 red on the identical revision). Nothing in the deploy process installed or updated CRDs — `installCRDs: false` dates from 4.2.2 (`5667b72`, "must be managed separately") but the separate management was never built.

## Safety

- All 12 CRDs carry `helm.sh/resource-policy: keep` (render-verified): `helm uninstall` never deletes them — Elastic CRs and data survive.
- No conflict with `createClusterScopedResources: false` (that flag only gates the webhook + storage-class validation, both already off).
- Precedent in this umbrella: the adfinis keycloak-operator already installs its CRDs via helm.

## Companion change

ExternalsPodiumD pipeline adds `--take-ownership` to both HelmDeploy tasks so existing clusters' manually-applied CRDs (no Helm ownership metadata) are adopted on first deploy; without it the deploy fails with `invalid ownership metadata`.

## Test plan

- `helm lint` + full render with `ci/lint-values.yaml`: clean, 12 CRDs in render, 24 keep-annotations.
- Branch-mode deploy to ontw-dim1 (first ECK-stack env): adoption path end-to-end, operator stable (restartCount 0 after 5+ min).

Follow-up (separate issue): CRD lifecycle for keycloak/redis/solr/zookeeper operators (helm `crds/` dir — never upgraded by helm).

🤖 Generated by Claude Code with help from Jimbo