### PR TITLE
feat(podiumd): adopt-eck-crds.sh helper — one-time CRD adoption instead of --take-ownership (IN-2402)

### DIFF
--- a/charts/podiumd/docs/migrating-to-eck-stack.md
+++ b/charts/podiumd/docs/migrating-to-eck-stack.md
@@ -157,19 +157,29 @@ Two requirements:
    must be allowed to create/update them. The SSC deploy pipeline runs
    `HelmDeploy` with `useClusterAdmin: true`, which covers this.
 2. **One-time adoption on clusters that already have the CRDs.** CRDs applied
-   in the kisselastic era (or by a manual `kubectl apply`) have no Helm
-   ownership metadata, and Helm refuses to overwrite them (`rendered manifests
-   contain a resource that already exists ... invalid ownership metadata`).
-   Either deploy with `--take-ownership` (helm >= 3.17; safe to keep in the
-   pipeline permanently), or annotate the CRDs once:
+   in the kisselastic era (by a manual `kubectl apply`, or owned by a
+   standalone `elastic-operator` release) don't belong to the `podiumd`
+   release, and Helm refuses to overwrite them (`rendered manifests contain a
+   resource that already exists ... invalid ownership metadata`). Run the
+   helper script once per cluster, **before** the first 4.8.0 deploy
+   (idempotent, safe to re-run; no-op on fresh clusters; `--dry-run` to
+   preview):
 
    ```bash
-   for crd in $(kubectl get crd -o name | grep 'k8s.elastic.co'); do
-     kubectl annotate "${crd}" meta.helm.sh/release-name=podiumd \
-       meta.helm.sh/release-namespace=podiumd --overwrite
-     kubectl label "${crd}" app.kubernetes.io/managed-by=Helm --overwrite
-   done
+   charts/podiumd/scripts/adopt-eck-crds.sh --context <kubectl-context>
    ```
+
+   After adoption the regular deploy needs no extra flags and the pipeline
+   needs no changes — Helm owns the CRDs from then on. The two CRDs new in
+   ECK 3.4.0 (`packageregistries`, `autoopsagentpolicies`) don't exist yet on
+   old clusters, so there is no conflict: Helm simply creates them on the
+   next deploy.
+
+   Alternative: deploy once with `--take-ownership` (helm >= 3.17). Works,
+   but the flag is not scoped to CRDs — it relaxes the ownership check for
+   **every** resource in the release, silently adopting conflicts a strict
+   deploy would flag. Prefer the one-time script and keep the pipeline
+   unchanged.
 
 Verify after the deploy (must print `12`):
 

--- a/charts/podiumd/docs/upgrade-from-4.7.6-to-4.8.0.md
+++ b/charts/podiumd/docs/upgrade-from-4.7.6-to-4.8.0.md
@@ -196,11 +196,17 @@ metadata-only — StatefulSet, PVCs and data are preserved. Full runbook:
 2. **One-time CRD adoption.** The chart now installs and upgrades the 12 ECK
    CRDs itself (`eck-operator.installCRDs: true`), so CRDs stay in lock-step
    with the operator automatically. On clusters where the CRDs already exist
-   without Helm ownership (kisselastic era), the first deploy must run with
-   `--take-ownership`, or the CRDs must be annotated once — commands and
-   details in runbook section 4b. Skipping this fails the deploy with
-   `invalid ownership metadata`; deploying with **stale** CRDs crashloops the
-   operator (also section 4b).
+   without `podiumd` release ownership (kisselastic era), run the helper
+   script once **before** the first 4.8.0 deploy — the deploy pipeline itself
+   needs no changes:
+
+   ```bash
+   charts/podiumd/scripts/adopt-eck-crds.sh --context <kubectl-context>
+   ```
+
+   Skipping this fails the deploy with `invalid ownership metadata`;
+   deploying with **stale** CRDs crashloops the operator. Details and the
+   `--take-ownership` alternative in runbook section 4b.
 3. **ACR mirror:** mirror `elastic/eck-operator:3.4.0` (see
    [`docs/images/images-baseline.yaml`](images/images-baseline.yaml)).
 

--- a/charts/podiumd/scripts/adopt-eck-crds.sh
+++ b/charts/podiumd/scripts/adopt-eck-crds.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# adopt-eck-crds.sh
+#
+# One-time Helm adoption of pre-existing ECK CRDs (*.k8s.elastic.co).
+#
+# Background:
+#   As of podiumd 4.8.0 the chart installs and upgrades the ECK CRDs itself
+#   (eck-operator.installCRDs: true). On clusters where the CRDs were applied
+#   earlier (kisselastic era, or a manual kubectl apply) they carry no Helm
+#   ownership metadata, and the first `helm upgrade` fails with
+#   "invalid ownership metadata". Run this script ONCE per cluster before that
+#   first deploy; afterwards the regular helm deploy/upgrade works unchanged —
+#   no pipeline changes and no --take-ownership flag needed.
+#
+#   Idempotent: safe to re-run. On a fresh cluster (no ECK CRDs) it is a
+#   no-op — helm installs the CRDs itself. CRDs that are missing on old
+#   clusters (packageregistries, autoopsagentpolicies) are simply created by
+#   helm on the next deploy; there is no conflict, so nothing to adopt.
+#
+# Usage:
+#   ./adopt-eck-crds.sh [OPTIONS]
+#
+# Options:
+#   --release NAME      Helm release name (default: podiumd)
+#   --namespace NS      Helm release namespace (default: podiumd)
+#   --context CONTEXT   kubectl context to use (default: current context)
+#   --dry-run           Show current vs target ownership metadata, change nothing
+#   -h, --help          Show this help message
+#
+# Prerequisites:
+#   - kubectl with cluster-admin on the target cluster (CRDs are cluster-scoped)
+#
+# Example:
+#   ./adopt-eck-crds.sh --context my-aks-cluster
+#   ./adopt-eck-crds.sh --dry-run
+
+set -euo pipefail
+
+RELEASE_NAME="podiumd"
+RELEASE_NS="podiumd"
+CONTEXT=""
+DRY_RUN=false
+
+usage() {
+  grep '^#' "$0" | grep -v '^#!/' | sed 's/^# //' | sed 's/^#//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)
+      RELEASE_NAME="$2"
+      shift 2
+      ;;
+    --namespace)
+      RELEASE_NS="$2"
+      shift 2
+      ;;
+    --context)
+      CONTEXT="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+kc() {
+  if [[ -n "${CONTEXT}" ]]; then
+    kubectl --context "${CONTEXT}" "$@"
+  else
+    kubectl "$@"
+  fi
+}
+
+echo "==> Looking for ECK CRDs (*.k8s.elastic.co)..."
+CRDS="$(kc get crd -o name | grep 'k8s\.elastic\.co' || true)"
+
+if [[ -z "${CRDS}" ]]; then
+  echo "==> No ECK CRDs present — fresh cluster, helm installs them on the first deploy. Nothing to do."
+  exit 0
+fi
+
+COUNT=0
+while IFS= read -r crd; do
+  COUNT=$((COUNT + 1))
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    CURRENT="$(kc get "${crd}" -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}')"
+    echo "    [dry-run] ${crd}: release-name '${CURRENT:-<none>}' -> '${RELEASE_NAME}'"
+  else
+    kc annotate "${crd}" \
+      "meta.helm.sh/release-name=${RELEASE_NAME}" \
+      "meta.helm.sh/release-namespace=${RELEASE_NS}" --overwrite >/dev/null
+    kc label "${crd}" app.kubernetes.io/managed-by=Helm --overwrite >/dev/null
+    echo "    adopted ${crd}"
+  fi
+done <<< "${CRDS}"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "==> [dry-run] ${COUNT} ECK CRDs found; nothing changed."
+else
+  echo "==> Adopted ${COUNT} ECK CRDs into Helm release ${RELEASE_NS}/${RELEASE_NAME}."
+  echo "==> The next helm deploy/upgrade manages them and creates any missing ones."
+fi


### PR DESCRIPTION
## What

Adds `charts/podiumd/scripts/adopt-eck-crds.sh`: a one-time, idempotent helper that adopts pre-existing ECK CRDs (`*.k8s.elastic.co`) into the `podiumd` Helm release by setting the `meta.helm.sh/release-name`/`release-namespace` annotations and the `app.kubernetes.io/managed-by=Helm` label. Supports `--release`, `--namespace`, `--context`, `--dry-run`.

## Why

PR #366 made the chart install/upgrade the 12 ECK CRDs itself (`eck-operator.installCRDs: true`). On kisselastic-era clusters the existing CRDs don't belong to the `podiumd` release, so the first deploy fails with `invalid ownership metadata` unless helm runs with `--take-ownership`. That flag is not scoped to CRDs — it relaxes the ownership check for **every** resource in the release — and requires a pipeline change. Running this script once per cluster keeps the deploy pipeline unchanged and strict.

## Docs

- `migrating-to-eck-stack.md` §4b: script is now the recommended adoption path; `--take-ownership` documented as alternative with its trade-off.
- `upgrade-from-4.7.6-to-4.8.0.md`: ECK action item 2 references the script.

## Verification

- `shellcheck` clean, bash 3 compatible.
- `--dry-run` tested against jim00 (`podiumd-jim00-aks`): finds the expected 10 kisselastic-era CRDs (there owned by a standalone `elastic-operator` release; `--overwrite` re-points them to `podiumd`).

Relates to IN-2402.

🤖 Generated by Claude Code with help from Jimbo